### PR TITLE
Improve right click menus

### DIFF
--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -115,10 +115,16 @@
       <string>Copy attribute to clipboard</string>
      </property>
  </widget>
-    <addaction name="actionEntryCopyPassword"/>
     <addaction name="actionEntryCopyUsername"/>
-    <addaction name="actionEntryEdit"/>
+	<addaction name="actionEntryCopyPassword"/>
+    <addaction name="actionEntryOpenUrl"/>
+    <addaction name="actionEntryAutoType"/>
+	<addaction name="separator"/>
+    <addaction name="actionEntryEdit"/>    
+    <addaction name="actionEntryClone"/>
     <addaction name="actionEntryDelete"/>
+	<addaction name="separator"/>
+	<addaction name="menuEntryCopyAttribute"/>
    </widget>
    <widget class="QMenu" name="menuGroups">
     <property name="title">


### PR DESCRIPTION
Improvement to the organization of the right click menu. More intuitive, since most commonly used options (copy username, copy password) are on top.
