### PR TITLE
Customizable toolbar icon size.

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -43,9 +43,14 @@ MainWindow::MainWindow()
     QAction* toggleViewAction = m_ui->toolBar->toggleViewAction();
     toggleViewAction->setText(tr("Show toolbar"));
     m_ui->menuView->addAction(toggleViewAction);
+    int toolbarIconSize = config()->get("ToolbarIconSize", 22).toInt();
+    setToolbarIconSize(toolbarIconSize);
     bool showToolbar = config()->get("ShowToolbar").toBool();
     m_ui->toolBar->setVisible(showToolbar);
     connect(m_ui->toolBar, SIGNAL(visibilityChanged(bool)), this, SLOT(saveToolbarState(bool)));
+    connect(m_ui->actionToolbarIconSize16, SIGNAL(triggered()), this, SLOT(setToolbarIconSize16()));
+    connect(m_ui->actionToolbarIconSize22, SIGNAL(triggered()), this, SLOT(setToolbarIconSize22()));
+    connect(m_ui->actionToolbarIconSize28, SIGNAL(triggered()), this, SLOT(setToolbarIconSize28()));
 
     m_clearHistoryAction = new QAction("Clear history", m_ui->menuFile);
     m_lastDatabasesActions = new QActionGroup(m_ui->menuRecentDatabases);
@@ -430,6 +435,30 @@ void MainWindow::showGroupContextMenu(const QPoint& globalPos)
 void MainWindow::saveToolbarState(bool value)
 {
     config()->set("ShowToolbar", value);
+}
+
+void MainWindow::setToolbarIconSize(int size)
+{
+    config()->set("ToolbarIconSize", size);
+    m_ui->toolBar->setIconSize(QSize(size, size));
+    m_ui->actionToolbarIconSize16->setChecked(size == 16);
+    m_ui->actionToolbarIconSize22->setChecked(size == 22);
+    m_ui->actionToolbarIconSize28->setChecked(size == 28);
+}
+
+void MainWindow::setToolbarIconSize16()
+{
+    setToolbarIconSize(16);
+}
+
+void MainWindow::setToolbarIconSize22()
+{
+    setToolbarIconSize(22);
+}
+
+void MainWindow::setToolbarIconSize28()
+{
+    setToolbarIconSize(28);
 }
 
 void MainWindow::setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -58,6 +58,10 @@ private Q_SLOTS:
     void showGroupContextMenu(const QPoint& globalPos);
     void saveToolbarState(bool value);
     void rememberOpenDatabases(const QString& filePath);
+    void setToolbarIconSize(int size);
+    void setToolbarIconSize16();
+    void setToolbarIconSize22();
+    void setToolbarIconSize28();
 
 private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -70,7 +70,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>20</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -143,6 +143,15 @@
     <property name="title">
      <string>View</string>
     </property>
+    <widget class="QMenu" name="menuToolbarIconSize">
+     <property name="title">
+      <string>Toolbar &amp;Icon Size</string>
+     </property>
+     <addaction name="actionToolbarIconSize16"/>
+     <addaction name="actionToolbarIconSize22"/>
+     <addaction name="actionToolbarIconSize28"/>
+    </widget>
+    <addaction name="menuToolbarIconSize"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEntries"/>
@@ -344,6 +353,30 @@
    </property>
    <property name="text">
     <string>Lock databases</string>
+   </property>
+  </action>
+  <action name="actionToolbarIconSize16">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;16x16</string>
+   </property>
+  </action>
+  <action name="actionToolbarIconSize22">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;22x22</string>
+   </property>
+  </action>
+  <action name="actionToolbarIconSize28">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>2&amp;8x28</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Add menu (in View) to select the toolbar icon size. 
Icon size is then stored in settings.
