### PR TITLE
Added option to minimize window when copying data to clipboard

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -93,6 +93,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("AutoSaveAfterEveryChange", false);
     m_defaults.insert("AutoSaveOnExit", false);
     m_defaults.insert("ShowToolbar", true);
+    m_defaults.insert("MinimizeOnCopy", false);
     m_defaults.insert("security/clearclipboard", true);
     m_defaults.insert("security/clearclipboardtimeout", 10);
 }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -27,6 +27,7 @@
 #include <QTimer>
 
 #include "autotype/AutoType.h"
+#include "core/Config.h"
 #include "core/FilePath.h"
 #include "core/Metadata.h"
 #include "core/Tools.h"
@@ -295,6 +296,10 @@ void DatabaseWidget::copyUsername()
     }
 
     clipboard()->setText(currentEntry->username());
+
+    if (config()->get("minimizeOnCopy").toBool()) {
+		window()->showMinimized();
+	}
 }
 
 void DatabaseWidget::copyPassword()
@@ -306,6 +311,10 @@ void DatabaseWidget::copyPassword()
     }
 
     clipboard()->setText(currentEntry->password());
+
+    if (config()->get("minimizeOnCopy").toBool()) {
+		window()->showMinimized();
+	}
 }
 
 void DatabaseWidget::copyAttribute(QAction* action)
@@ -317,6 +326,10 @@ void DatabaseWidget::copyAttribute(QAction* action)
     }
 
     clipboard()->setText(currentEntry->attributes()->value(action->text()));
+
+    if (config()->get("minimizeOnCopy").toBool()) {
+		window()->showMinimized();
+	}
 }
 
 void DatabaseWidget::performAutoType()

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -58,6 +58,7 @@ void SettingsWidget::loadSettings()
     m_generalUi->modifiedExpandedChangedCheckBox->setChecked(config()->get("ModifiedOnExpandedStateChanges").toBool());
     m_generalUi->autoSaveAfterEveryChangeCheckBox->setChecked(config()->get("AutoSaveAfterEveryChange").toBool());
     m_generalUi->autoSaveOnExitCheckBox->setChecked(config()->get("AutoSaveOnExit").toBool());
+    m_generalUi->minimizeOnCopyCheckBox->setChecked(config()->get("MinimizeOnCopy").toBool());
 
     m_globalAutoTypeKey = static_cast<Qt::Key>(config()->get("GlobalAutoTypeKey").toInt());
     m_globalAutoTypeModifiers = static_cast<Qt::KeyboardModifiers>(config()->get("GlobalAutoTypeModifiers").toInt());
@@ -78,6 +79,7 @@ void SettingsWidget::saveSettings()
     config()->set("ModifiedOnExpandedStateChanges", m_generalUi->modifiedExpandedChangedCheckBox->isChecked());
     config()->set("AutoSaveAfterEveryChange", m_generalUi->autoSaveAfterEveryChangeCheckBox->isChecked());
     config()->set("AutoSaveOnExit", m_generalUi->autoSaveOnExitCheckBox->isChecked());
+    config()->set("MinimizeOnCopy", m_generalUi->minimizeOnCopyCheckBox->isChecked());
     config()->set("GlobalAutoTypeKey", m_generalUi->autoTypeShortcutWidget->key());
     config()->set("GlobalAutoTypeModifiers", static_cast<int>(m_generalUi->autoTypeShortcutWidget->modifiers()));
     config()->set("security/clearclipboard", m_secUi->clearClipboardCheckBox->isChecked());

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>456</width>
-    <height>146</height>
+    <height>185</height>
    </rect>
   </property>
   <layout class="QFormLayout" name="formLayout">
@@ -45,20 +45,27 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Global Auto-Type shortcut</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="ShortcutWidget" name="autoTypeShortcutWidget"/>
    </item>
    <item row="1" column="0">
     <widget class="QCheckBox" name="openPreviousDatabasesOnStartupCheckBox">
      <property name="text">
       <string>Open previous databases on startup</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QCheckBox" name="minimizeOnCopyCheckBox">
+     <property name="text">
+      <string>Minimize when copying to clipboard</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
If option is enabled, it minimize window when copying username, password, or attribute. Useful when the place where you want to paste it is below keepassx window.
