### PR TITLE
Use group icon for new entries

### DIFF
--- a/src/autotype/AutoTypeAction.cpp
+++ b/src/autotype/AutoTypeAction.cpp
@@ -32,7 +32,6 @@ AutoTypeAction* AutoTypeChar::clone()
 void AutoTypeChar::accept(AutoTypeExecutor* executor)
 {
     executor->execChar(this);
-    Tools::wait(10);
 }
 
 
@@ -49,7 +48,6 @@ AutoTypeAction* AutoTypeKey::clone()
 void AutoTypeKey::accept(AutoTypeExecutor* executor)
 {
     executor->execKey(this);
-    Tools::wait(10);
 }
 
 


### PR DESCRIPTION
With this change, new entries get the icon of the group instead of the default icon, when group icon is different than default group icon.
