### PR TITLE
Excluded group settings for search.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,6 +188,7 @@ set(keepassx_FORMS
     gui/SearchWidget.ui
     gui/SettingsWidgetGeneral.ui
     gui/SettingsWidgetSecurity.ui
+    gui/SettingsWidgetSearch.ui
     gui/WelcomeWidget.ui
     gui/entry/EditEntryWidgetAdvanced.ui
     gui/entry/EditEntryWidgetAutoType.ui

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -96,6 +96,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("MinimizeOnCopy", false);
     m_defaults.insert("security/clearclipboard", true);
     m_defaults.insert("security/clearclipboardtimeout", 10);
+    m_defaults.insert("search/GroupExcludedPatterns", "Backup");
 }
 
 Config* Config::instance()

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -612,8 +612,23 @@ void Group::recCreateDelObjects()
     }
 }
 
+bool Group::nameMatch(const QString& searchTerm)
+{
+    QRegExp rx(searchTerm);
+    rx.setPatternSyntax(QRegExp::Wildcard);
+    return rx.exactMatch(name());
+}
+
+bool Group::nameMatch(const QStringList& searchTerms)
+{
+    Q_FOREACH (const QString& searchTerm, searchTerms) {
+        if (nameMatch(searchTerm)) return true;
+    }
+    return false;
+}
+
 QList<Entry*> Group::search(const QString& searchTerm, Qt::CaseSensitivity caseSensitivity,
-                            bool resolveInherit)
+                            bool resolveInherit, const QStringList& groupExcludedPatterns)
 {
     QList<Entry*> searchResult;
     if (includeInSearch(resolveInherit)) {
@@ -623,6 +638,7 @@ QList<Entry*> Group::search(const QString& searchTerm, Qt::CaseSensitivity caseS
             }
         }
         Q_FOREACH (Group* group, m_children) {
+            if (group->nameMatch(groupExcludedPatterns)) continue;
             searchResult.append(group->search(searchTerm, caseSensitivity, false));
         }
     }

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -112,7 +112,7 @@ public:
     Database* exportToDb();
 
     QList<Entry*> search(const QString& searchTerm, Qt::CaseSensitivity caseSensitivity,
-                         bool resolveInherit = true);
+                         bool resolveInherit = true, const QStringList& groupExcludedPatterns = QStringList());
 
 Q_SIGNALS:
     void dataChanged(Group* group);
@@ -148,6 +148,8 @@ private:
     void recCreateDelObjects();
     void updateTimeinfo();
     bool includeInSearch(bool resolveInherit);
+    bool nameMatch(const QString& searchTerm);
+    bool nameMatch(const QStringList& searchTerms); 
 
     QPointer<Database> m_db;
     Uuid m_uuid;

--- a/src/format/KeePass1Reader.cpp
+++ b/src/format/KeePass1Reader.cpp
@@ -208,13 +208,6 @@ Database* KeePass1Reader::readDatabase(QIODevice* device, const QString& passwor
 
     db->rootGroup()->setName(tr("Root"));
 
-    Q_FOREACH (Group* group, db->rootGroup()->children()) {
-        if (group->name() == "Backup") {
-            group->setSearchingEnabled(Group::Disable);
-            group->setAutoTypeEnabled(Group::Disable);
-        }
-    }
-
     Q_ASSERT(m_tmpParent->children().isEmpty());
     Q_ASSERT(m_tmpParent->entries().isEmpty());
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -709,7 +709,9 @@ void DatabaseWidget::search()
     else {
         sensitivity = Qt::CaseInsensitive;
     }
-    QList<Entry*> searchResult = searchGroup->search(m_searchUi->searchEdit->text(), sensitivity);
+    
+    QStringList groupExcludedPatterns = config()->get("search/GroupExcludedPatterns").toString().split("\n");
+    QList<Entry*> searchResult = searchGroup->search(m_searchUi->searchEdit->text(), sensitivity, true, groupExcludedPatterns);
 
 
     m_entryView->setEntryList(searchResult);

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -18,6 +18,7 @@
 #include "SettingsWidget.h"
 #include "ui_SettingsWidgetGeneral.h"
 #include "ui_SettingsWidgetSecurity.h"
+#include "ui_SettingsWidgetSearch.h"
 
 #include "autotype/AutoType.h"
 #include "core/Config.h"
@@ -26,15 +27,19 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     : EditWidget(parent)
     , m_secWidget(new QWidget())
     , m_generalWidget(new QWidget())
+    , m_searchWidget(new QWidget())
     , m_secUi(new Ui::SettingsWidgetSecurity())
     , m_generalUi(new Ui::SettingsWidgetGeneral())
+    , m_searchUi(new Ui::SettingsWidgetSearch())
 {
     setHeadline(tr("Application Settings"));
 
     m_secUi->setupUi(m_secWidget);
     m_generalUi->setupUi(m_generalWidget);
+    m_searchUi->setupUi(m_searchWidget);
     add(tr("General"), m_generalWidget);
     add(tr("Security"), m_secWidget);
+    add(tr("Search"), m_searchWidget);
 
     m_generalUi->autoTypeShortcutWidget->setVisible(autoType()->isAvailable());
     m_generalUi->autoTypeShortcutLabel->setVisible(autoType()->isAvailable());
@@ -73,6 +78,8 @@ void SettingsWidget::loadSettings()
 
     m_secUi->clearClipboardCheckBox->setChecked(config()->get("security/clearclipboard").toBool());
     m_secUi->clearClipboardSpinBox->setValue(config()->get("security/clearclipboardtimeout").toInt());
+    
+    m_searchUi->searchGroupExcludedPatternsTextEdit->setPlainText(config()->get("search/GroupExcludedPatterns").toString());
 
     setCurrentRow(0);
 }
@@ -91,7 +98,8 @@ void SettingsWidget::saveSettings()
     }
     config()->set("security/clearclipboard", m_secUi->clearClipboardCheckBox->isChecked());
     config()->set("security/clearclipboardtimeout", m_secUi->clearClipboardSpinBox->value());
-
+    config()->set("search/GroupExcludedPatterns", m_searchUi->searchGroupExcludedPatternsTextEdit->toPlainText());
+    
     Q_EMIT editFinished(true);
 }
 

--- a/src/gui/SettingsWidget.h
+++ b/src/gui/SettingsWidget.h
@@ -23,6 +23,7 @@
 namespace Ui {
     class SettingsWidgetGeneral;
     class SettingsWidgetSecurity;
+    class SettingsWidgetSearch;
 }
 
 class SettingsWidget : public EditWidget
@@ -45,8 +46,10 @@ private Q_SLOTS:
 private:
     QWidget* const m_secWidget;
     QWidget* const m_generalWidget;
+    QWidget* const m_searchWidget;
     const QScopedPointer<Ui::SettingsWidgetSecurity> m_secUi;
     const QScopedPointer<Ui::SettingsWidgetGeneral> m_generalUi;
+    const QScopedPointer<Ui::SettingsWidgetSearch> m_searchUi;
     Qt::Key m_globalAutoTypeKey;
     Qt::KeyboardModifiers m_globalAutoTypeModifiers;
 };

--- a/src/gui/SettingsWidgetSearch.ui
+++ b/src/gui/SettingsWidgetSearch.ui
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SettingsWidgetSearch</class>
+ <widget class="QWidget" name="SettingsWidgetSearch">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>374</width>
+    <height>303</height>
+   </rect>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <property name="fieldGrowthPolicy">
+    <enum>QFormLayout::FieldsStayAtSizeHint</enum>
+   </property>
+   <item row="2" column="0">
+    <widget class="QLabel" name="searchGroupExcludedPatternsLabel">
+     <property name="text">
+      <string>Group exclude patterns:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QPlainTextEdit" name="searchGroupExcludedPatternsTextEdit"/>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="searchGroupExcludedPatternsHint">
+     <property name="text">
+      <string>(One pattern per line)</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This pull request is to allow users to specify group patterns that should be excluded from search results. Currently, 'Backup' is excluded by default, however depending on the plugin, localization or user preferences, the backup folder might be named differently (in my case, it was localized to French language).

Also, some users might want to manually put aside certain passwords without deleting them completely. That might happen, for example, when certain passwords are required for a project but later becomes unneeded once the project is complete. You might want to keep them but don't want them to show up in search results.

The proposed feature basically allows a bit more flexibility on what should be excluded. The following are the main changes:
- Added setting to allow users to exclude certain groups from search results (based on wildcard pattern).
- Added corresponding Search panel in Settings window.
- Added 'Backup' pattern by default, but users can remove it, as needed.
- Removed hard-coded exclusion of 'Backup' group, since the name might be different depending on plugin or localization settings.

I didn't add any tests yet but I don't mind doing so if needed.
