### PR TITLE
Make first entry active when entry list changes.

### DIFF
--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -62,22 +62,20 @@ void EntryView::keyPressEvent(QKeyEvent* event)
 void EntryView::setGroup(Group* group)
 {
     m_model->setGroup(group);
-
-    if(m_model->rowCount() > 0) {
-        QModelIndex index = m_sortModel->mapToSource(m_sortModel->index(0, 0));
-        setCurrentEntry(m_model->entryFromIndex(index));
-    }
-    else {
-        Q_EMIT entrySelectionChanged();
-    }
+    setFirstEntryActive();
 }
 
 void EntryView::setEntryList(const QList<Entry*>& entries)
 {
     m_model->setEntryList(entries);
+    setFirstEntryActive();
+}
 
-    if(!entries.isEmpty()) {
-        setCurrentEntry(entries.first());
+void EntryView::setFirstEntryActive()
+{
+    if(m_model->rowCount() > 0) {
+        QModelIndex index = m_sortModel->mapToSource(m_sortModel->index(0, 0));
+        setCurrentEntry(m_model->entryFromIndex(index));
     }
     else {
         Q_EMIT entrySelectionChanged();

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -42,6 +42,7 @@ public:
     Entry* entryFromIndex(const QModelIndex& index);
     void setEntryList(const QList<Entry*>& entries);
     bool inEntryListMode();
+    void setFirstEntryActive();
 
 public Q_SLOTS:
     void setGroup(Group* group);


### PR DESCRIPTION
This makes it a lot easier to always use the keyboard. When searching
for an entry or changing groups, the first entry (if one is available)
will be made the active entry.
