### PR TITLE
Fixed location of config file on Mac (and probably Windows).

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -71,7 +71,8 @@ Config::Config(QObject* parent)
     userPath += "/keepassx/";
 #else
     userPath = QDir::fromNativeSeparators(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
-    // storageLocation() appends the application name ("/keepassx/") to the end
+    // storageLocation() appends the application name ("/keepassx") to the end
+    userPath += "/";
 #endif
 
     userPath += "keepassx2.ini";


### PR DESCRIPTION
keepass2.ini was being stored in ~/Library/Application Support/keepassxkeepassx2.ini. I didn't test on Windows but it's likely doing the same after looking at the Qt source.
