### PR TITLE
Add option to show a confirmation dialog before locking all open databases

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -90,6 +90,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("RememberLastDatabases", true);
     m_defaults.insert("OpenPreviousDatabasesOnStartup", true);
     m_defaults.insert("ModifiedOnExpandedStateChanges", true);
+    m_defaults.insert("AskForConfirmationBeforeLockingDatabases", false);
     m_defaults.insert("AutoSaveAfterEveryChange", false);
     m_defaults.insert("AutoSaveOnExit", false);
     m_defaults.insert("ShowToolbar", true);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -20,6 +20,7 @@
 
 #include <QCloseEvent>
 #include <QShortcut>
+#include <QMessageBox>
 
 #include "autotype/AutoType.h"
 #include "core/Config.h"
@@ -160,7 +161,7 @@ MainWindow::MainWindow()
             SLOT(changeDatabaseSettings()));
     connect(m_ui->actionImportKeePass1, SIGNAL(triggered()), m_ui->tabWidget,
             SLOT(importKeePass1Database()));
-    connect(m_ui->actionLockDatabases, SIGNAL(triggered()), m_ui->tabWidget,
+    connect(m_ui->actionLockDatabases, SIGNAL(triggered()), this,
             SLOT(lockDatabases()));
     connect(m_ui->actionQuit, SIGNAL(triggered()), SLOT(close()));
 
@@ -510,5 +511,17 @@ void MainWindow::applySettingsChanges()
     }
     else {
         m_inactivityTimer->deactivate();
+    }
+}
+
+void MainWindow::lockDatabases()
+{
+    if (!config()->get("AskForConfirmationBeforeLockingDatabases").toBool()
+        || QMessageBox::question(this,
+                              tr("Lock databases?"),
+                              tr("Do you really want to lock all open databases?"),
+                              QMessageBox::Yes | QMessageBox::No,
+                              QMessageBox::Yes) == QMessageBox::Yes) {
+        m_ui->tabWidget->lockDatabases();
     }
 }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -61,6 +61,7 @@ private Q_SLOTS:
     void saveToolbarState(bool value);
     void rememberOpenDatabases(const QString& filePath);
     void applySettingsChanges();
+    void lockDatabases();
 
 private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -64,6 +64,7 @@ void SettingsWidget::loadSettings()
     m_generalUi->openPreviousDatabasesOnStartupCheckBox->setChecked(
         config()->get("OpenPreviousDatabasesOnStartup").toBool());
     m_generalUi->modifiedExpandedChangedCheckBox->setChecked(config()->get("ModifiedOnExpandedStateChanges").toBool());
+    m_generalUi->askForConfirmationBeforeLockingDatabasesCheckBox->setChecked(config()->get("AskForConfirmationBeforeLockingDatabases").toBool());
     m_generalUi->autoSaveAfterEveryChangeCheckBox->setChecked(config()->get("AutoSaveAfterEveryChange").toBool());
     m_generalUi->autoSaveOnExitCheckBox->setChecked(config()->get("AutoSaveOnExit").toBool());
     m_generalUi->minimizeOnCopyCheckBox->setChecked(config()->get("MinimizeOnCopy").toBool());
@@ -107,6 +108,8 @@ void SettingsWidget::saveSettings()
                   m_generalUi->openPreviousDatabasesOnStartupCheckBox->isChecked());
     config()->set("ModifiedOnExpandedStateChanges",
                   m_generalUi->modifiedExpandedChangedCheckBox->isChecked());
+    config()->set("AskForConfirmationBeforeLockingDatabases",
+                  m_generalUi->askForConfirmationBeforeLockingDatabasesCheckBox->isChecked());
     config()->set("AutoSaveAfterEveryChange",
                   m_generalUi->autoSaveAfterEveryChangeCheckBox->isChecked());
     config()->set("AutoSaveOnExit", m_generalUi->autoSaveOnExitCheckBox->isChecked());

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>456</width>
-    <height>288</height>
+    <width>503</width>
+    <height>302</height>
    </rect>
   </property>
   <layout class="QFormLayout" name="formLayout">
@@ -41,60 +41,67 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QCheckBox" name="autoSaveOnExitCheckBox">
      <property name="text">
       <string>Automatically save on exit</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QCheckBox" name="autoSaveAfterEveryChangeCheckBox">
      <property name="text">
       <string>Automatically save after every change</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QCheckBox" name="minimizeOnCopyCheckBox">
      <property name="text">
       <string>Minimize when copying to clipboard</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QCheckBox" name="useGroupIconOnEntryCreationCheckBox">
      <property name="text">
       <string>Use group icon on entry creation</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="autoTypeShortcutLabel">
      <property name="text">
       <string>Global Auto-Type shortcut</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="9" column="1">
     <widget class="ShortcutWidget" name="autoTypeShortcutWidget"/>
    </item>
-   <item row="8" column="0">
+   <item row="10" column="0">
     <widget class="QCheckBox" name="autoTypeEntryTitleMatchCheckBox">
      <property name="text">
       <string>Use entry title to match windows for global auto-type</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="0">
+   <item row="12" column="0">
     <widget class="QLabel" name="languageLabel">
      <property name="text">
       <string>Language</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
+   <item row="12" column="1">
     <widget class="QComboBox" name="languageComboBox"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="askForConfirmationBeforeLockingDatabasesCheckBox">
+     <property name="text">
+      <string>Ask for confirmation before locking databases</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
I constantly lock my databases by accident. So I decided to add an option that displays a simple confirmation dialog before actually locking them. Hope you appreciate the change. 
