### PR TITLE
adding a .travis.yml file for travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: cpp
+compiler: gcc
+install: sudo apt-get install build-essential libqt4-dev libgcrypt11-dev zlib1g-dev libxtst-dev
+before_script: mkdir build && pushd build
+script: cmake .. && make && make test


### PR DESCRIPTION
I've added a `.travis.yml` file so that the test suite can be run automatically by travis-ci.org. All you need to do is sign in to https://travis-ci.org with your github account and turn on this repository. Then the tests will be run on every push and pull request. You can see what a test run looks like here: https://travis-ci.org/mhrivnak/keepassx
