### PR TITLE
Fix vertical text misalignment on buttons on OS X

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,14 @@ int main(int argc, char** argv)
     Tools::disableCoreDumps();
 #endif
 
+#ifdef Q_OS_MACX
+    if (QSysInfo::MacintoshVersion > QSysInfo::MV_10_8) {
+        // fix Mac OS X 10.9 (mavericks) font issue
+        // https://bugreports.qt-project.org/browse/QTBUG-32789
+        QFont::insertSubstitution(".Lucida Grande UI", "Lucida Grande");
+    }
+#endif
+
     Application app(argc, argv);
     Application::setApplicationName("keepassx");
     Application::setApplicationVersion(KEEPASSX_VERSION);


### PR DESCRIPTION
Fix as described here: http://successfulsoftware.net/2013/10/23/fixing-qt-4-for-mac-os-x-10-9-mavericks/

How official KeePassX 2.0 alpha 6 looks on OS X 10.9:
http://img-fotki.yandex.ru/get/6844/25698687.7/0_ce1d7_fe476d00_orig.png

And after the fix:
http://img-fotki.yandex.ru/get/4807/25698687.7/0_ce1d8_42c7075c_orig.png
