### PR TITLE
Make Ctrl+F not toggle the search mode but always enable it.

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -718,24 +718,6 @@ void DatabaseWidget::openSearch()
     }
 }
 
-void DatabaseWidget::toggleSearch()
-{
-    if (isInSearchMode()) {
-        if (m_searchUi->searchEdit->hasFocus()) {
-            closeSearch();
-        }
-        else {
-            m_searchUi->searchEdit->selectAll();
-            m_searchUi->searchEdit->setFocus();
-            // make sure the search action is checked again
-            emitCurrentModeChanged();
-        }
-    }
-    else {
-        showSearch();
-    }
-}
-
 void DatabaseWidget::closeSearch()
 {
     Q_ASSERT(m_lastGroup);

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -118,7 +118,6 @@ public Q_SLOTS:
     void switchToOpenDatabase(const QString& fileName, const QString& password, const QString& keyFile);
     void switchToImportKeepass1(const QString& fileName);
     void openSearch();
-    void toggleSearch();
 
 private Q_SLOTS:
     void entryActivationSignalReceived(Entry* entry, EntryModel::ModelColumn column);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -119,7 +119,7 @@ MainWindow::MainWindow()
 
     m_ui->actionAbout->setIcon(filePath()->icon("actions", "help-about"));
 
-    m_ui->actionToggleSearch->setIcon(filePath()->icon("actions", "system-search"));
+    m_ui->actionSearch->setIcon(filePath()->icon("actions", "system-search"));
 
     m_actionMultiplexer.connect(SIGNAL(currentModeChanged(DatabaseWidget::Mode)),
                                 this, SLOT(setMenuActionState(DatabaseWidget::Mode)));
@@ -200,8 +200,6 @@ MainWindow::MainWindow()
 
     connect(m_ui->actionAbout, SIGNAL(triggered()), SLOT(showAboutDialog()));
 
-    m_actionMultiplexer.connect(m_ui->actionToggleSearch, SIGNAL(triggered()),
-                                SLOT(toggleSearch()));
     m_actionMultiplexer.connect(m_ui->actionSearch, SIGNAL(triggered()),
                                 SLOT(openSearch()));
 
@@ -299,8 +297,6 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             m_ui->actionGroupDelete->setEnabled(groupSelected && dbWidget->canDeleteCurrentGroup());
             // TODO: get checked state from db widget
             m_ui->actionSearch->setEnabled(true);
-            m_ui->actionToggleSearch->setEnabled(true);
-            m_ui->actionToggleSearch->setChecked(inSearch);
             m_ui->actionChangeMasterKey->setEnabled(true);
             m_ui->actionChangeDatabaseSettings->setEnabled(true);
             m_ui->actionDatabaseSave->setEnabled(true);
@@ -324,7 +320,6 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             m_ui->menuEntryCopyAttribute->setEnabled(false);
 
             m_ui->actionSearch->setEnabled(false);
-            m_ui->actionToggleSearch->setEnabled(false);
             m_ui->actionChangeMasterKey->setEnabled(false);
             m_ui->actionChangeDatabaseSettings->setEnabled(false);
             m_ui->actionDatabaseSave->setEnabled(false);
@@ -351,7 +346,6 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
         m_ui->menuEntryCopyAttribute->setEnabled(false);
 
         m_ui->actionSearch->setEnabled(false);
-        m_ui->actionToggleSearch->setEnabled(false);
         m_ui->actionChangeMasterKey->setEnabled(false);
         m_ui->actionChangeDatabaseSettings->setEnabled(false);
         m_ui->actionDatabaseSave->setEnabled(false);

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -177,7 +177,7 @@
    <addaction name="actionEntryCopyPassword"/>
    <addaction name="separator"/>
    <addaction name="actionLockDatabases"/>
-   <addaction name="actionToggleSearch"/>
+   <addaction name="actionSearch"/>
   </widget>
   <action name="actionQuit">
    <property name="text">
@@ -304,14 +304,6 @@
    </property>
   </action>
   <action name="actionSearch">
-   <property name="text">
-    <string>Find</string>
-   </property>
-  </action>
-  <action name="actionToggleSearch">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
    <property name="enabled">
     <bool>false</bool>
    </property>

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -166,18 +166,18 @@ void TestGui::testAddEntry()
 
 void TestGui::testSearch()
 {
-    QAction* toggleSearchAction = m_mainWindow->findChild<QAction*>("actionToggleSearch");
-    QVERIFY(toggleSearchAction->isEnabled());
+    QAction* searchAction = m_mainWindow->findChild<QAction*>("actionSearch");
+    QVERIFY(searchAction->isEnabled());
     QToolBar* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
-    QWidget* toggleSearchActionWidget = toolBar->widgetForAction(toggleSearchAction);
+    QWidget* searchActionWidget = toolBar->widgetForAction(searchAction);
     EntryView* entryView = m_dbWidget->findChild<EntryView*>("entryView");
     QLineEdit* searchEdit = m_dbWidget->findChild<QLineEdit*>("searchEdit");
     QToolButton* clearSearch = m_dbWidget->findChild<QToolButton*>("clearButton");
 
     QVERIFY(!searchEdit->hasFocus());
 
-    // Toggle
-    QTest::mouseClick(toggleSearchActionWidget, Qt::LeftButton);
+    // Enter search
+    QTest::mouseClick(searchActionWidget, Qt::LeftButton);
     QTRY_VERIFY(searchEdit->hasFocus());
     // Search for "ZZZ"
     QTest::keyClicks(searchEdit, "ZZZ");
@@ -185,17 +185,17 @@ void TestGui::testSearch()
     // Escape
     QTest::keyClick(m_mainWindow, Qt::Key_Escape);
     QTRY_VERIFY(!searchEdit->hasFocus());
-    // Toggle again
-    QTest::mouseClick(toggleSearchActionWidget, Qt::LeftButton);
+    // Enter search again
+    QTest::mouseClick(searchActionWidget, Qt::LeftButton);
     QTRY_VERIFY(searchEdit->hasFocus());
     // Input and clear
     QTest::keyClicks(searchEdit, "ZZZ");
     QTRY_COMPARE(searchEdit->text(), QString("ZZZ"));
     QTest::mouseClick(clearSearch, Qt::LeftButton);
     QTRY_COMPARE(searchEdit->text(), QString(""));
-    // Ctrl+F should select the current text
+    // Triggering search should select the existing text
     QTest::keyClicks(searchEdit, "ZZZ");
-    QTest::keyClick(m_mainWindow, Qt::Key_F, Qt::ControlModifier);
+    QTest::mouseClick(searchActionWidget, Qt::LeftButton);
     QTRY_VERIFY(searchEdit->hasFocus());
     // Search for "some"
     QTest::keyClicks(searchEdit, "some");


### PR DESCRIPTION
Switching back from other applications, the previous behavior of Ctrl+F would often bother you in that it would dismiss the search widget if it was already enabled when you meant by the key you wanted to perform a search.

Making Ctrl+F always set you in search mode should save user from having to care about the mode which is persistent across application switching and database locking.
