### PR TITLE
implement support for Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ project(KeePassX)
 
 cmake_minimum_required(VERSION 2.6.4)
 
+option(USE_QT5 "Force use of Qt5." $ENV{USE_QT5})
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 include(CheckCCompilerFlag)
@@ -154,6 +156,24 @@ else()
   set(DATA_INSTALL_DIR   "${CMAKE_INSTALL_DATAROOTDIR}/keepassx")
 endif()
 
+
+if(USE_QT5)
+if(WITH_TESTS)
+  find_package(Qt5Test REQUIRED)
+  include_directories(${Qt5Test_INCLUDE_DIRS})
+endif(WITH_TESTS)
+find_package(Qt5Widgets REQUIRED)
+find_package(Qt5Concurrent REQUIRED)
+if(UNIX AND NOT APPLE)
+  find_package(Qt5DBus REQUIRED)
+  find_package(Qt5X11Extras REQUIRED)
+  include_directories(${Qt5DBus_INCLUDE_DIRS})
+  include_directories(${Qt5X11Extras_INCLUDE_DIRS})
+endif()
+include_directories(${Qt5Widgets_INCLUDE_DIRS})
+include_directories(${Qt5Concurrent_INCLUDE_DIRS})
+ADD_DEFINITIONS(-fPIC)
+else()
 if(WITH_TESTS)
   enable_testing()
 endif(WITH_TESTS)
@@ -165,6 +185,7 @@ endif()
 
 find_package(Qt4 4.6.0 REQUIRED ${QT_REQUIRED_MODULES})
 include(${QT_USE_FILE})
+endif()
 # Debian sets the the build type to None for package builds.
 # Make sure we don't enable asserts there.
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS_NONE QT_NO_DEBUG)

--- a/share/translations/CMakeLists.txt
+++ b/share/translations/CMakeLists.txt
@@ -19,7 +19,12 @@ list(REMOVE_ITEM TRANSLATION_FILES keepassx_en.ts)
 list(REMOVE_ITEM TRANSLATION_FILES ${TRANSLATION_EN_ABS})
 message(STATUS ${TRANSLATION_FILES})
 
-qt4_add_translation(QM_FILES ${TRANSLATION_FILES})
+if(USE_QT5)
+  find_package(Qt5LinguistTools REQUIRED)
+  qt5_add_translation(QM_FILES ${TRANSLATION_FILES})
+else()
+  qt4_add_translation(QM_FILES ${TRANSLATION_FILES})
+endif()
 
 install(FILES ${QM_FILES} DESTINATION ${DATA_INSTALL_DIR}/translations)
 add_custom_target(translations DEPENDS ${QM_FILES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,8 +43,6 @@ set(keepassx_SOURCES
     core/ListDeleter.h
     core/Metadata.cpp
     core/PasswordGenerator.cpp
-    core/qsavefile.cpp
-    core/qsavefile_p.h
     core/SignalMultiplexer.cpp
     core/TimeDelta.cpp
     core/TimeInfo.cpp
@@ -130,6 +128,14 @@ if(NOT GCRYPT_HAS_SALSA20)
   )
 endif()
 
+if (NOT USE_QT5)
+  set(keepassx_SOURCES
+      ${keepassx_SOURCES}
+      core/qsavefile.cpp
+      core/qsavefile_p.h
+  )
+endif()
+
 set(keepassx_SOURCES_MAINEXE
     main.cpp
 )
@@ -149,7 +155,6 @@ set(keepassx_MOC
     core/Group.h
     core/InactivityTimer.h
     core/Metadata.h
-    core/qsavefile.h
     gui/AboutDialog.h
     gui/Application.h
     gui/ChangeMasterKeyWidget.h
@@ -192,6 +197,12 @@ set(keepassx_MOC
     streams/StoreDataStream.h
     streams/SymmetricCipherStream.h
 )
+if (NOT USE_QT5)
+  set(keepassx_MOC
+      ${keepassx_MOC}
+      core/qsavefile.h
+  )
+endif()
 
 set(keepassx_FORMS
     gui/AboutDialog.ui
@@ -220,13 +231,31 @@ if(MINGW)
       ${CMAKE_SOURCE_DIR}/share/windows/icon.rc)
 endif()
 
+if(USE_QT5)
+qt5_wrap_ui(keepassx_SOURCES ${keepassx_FORMS})
+qt5_wrap_cpp(keepassx_SOURCES ${keepassx_MOC})
+else()
 qt4_wrap_ui(keepassx_SOURCES ${keepassx_FORMS})
 qt4_wrap_cpp(keepassx_SOURCES ${keepassx_MOC})
+endif()
 
 add_library(keepassx_core STATIC ${keepassx_SOURCES})
 set_target_properties(keepassx_core PROPERTIES COMPILE_DEFINITIONS KEEPASSX_BUILDING_CORE)
 
 add_executable(${PROGNAME} WIN32 MACOSX_BUNDLE ${keepassx_SOURCES_MAINEXE})
+if(USE_QT5)
+target_link_libraries(${PROGNAME}
+                      keepassx_core
+                      Qt5::Core
+                      Qt5::Widgets
+                      Qt5::Concurrent
+                      ${GCRYPT_LIBRARIES}
+                      ${ZLIB_LIBRARIES})
+
+if(UNIX AND NOT APPLE)
+  target_link_libraries(${PROGNAME} Qt5::DBus)
+endif()
+else()
 target_link_libraries(${PROGNAME}
                       keepassx_core
                       ${QT_QTCORE_LIBRARY}
@@ -236,6 +265,7 @@ target_link_libraries(${PROGNAME}
 
 if(UNIX AND NOT APPLE)
   target_link_libraries(${PROGNAME} ${QT_QTDBUS_LIBRARY})
+endif()
 endif()
 
 set_target_properties(${PROGNAME} PROPERTIES ENABLE_EXPORTS ON)

--- a/src/autotype/test/AutoTypeTest.cpp
+++ b/src/autotype/test/AutoTypeTest.cpp
@@ -117,5 +117,6 @@ void AutoTypeExecturorTest::execKey(AutoTypeKey* action)
 {
     m_platform->addActionKey(action);
 }
-
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
 Q_EXPORT_PLUGIN2(keepassx-autotype-test, AutoTypePlatformTest)
+#endif

--- a/src/autotype/test/AutoTypeTest.h
+++ b/src/autotype/test/AutoTypeTest.h
@@ -31,6 +31,9 @@ class AutoTypePlatformTest : public QObject,
 {
     Q_OBJECT
     Q_INTERFACES(AutoTypePlatformInterface AutoTypeTestInterface)
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+    Q_PLUGIN_METADATA(IID "org.keepassx.AutoTypeTestInterface/1")
+#endif
 
 public:
     QString keyToString(Qt::Key key);

--- a/src/autotype/test/CMakeLists.txt
+++ b/src/autotype/test/CMakeLists.txt
@@ -6,7 +6,15 @@ set(autotype_test_MOC
     AutoTypeTest.h
 )
 
-qt4_wrap_cpp(autotype_test_SOURCES ${autotype_test_MOC})
+if(USE_QT5)
+  qt5_wrap_cpp(autotype_test_SOURCES ${autotype_test_MOC})
+else()
+  qt4_wrap_cpp(autotype_test_SOURCES ${autotype_test_MOC})
+endif()
 
 add_library(keepassx-autotype-test MODULE ${autotype_test_SOURCES})
-target_link_libraries(keepassx-autotype-test testautotype ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY})
+if(USE_QT5)
+  target_link_libraries(keepassx-autotype-test testautotype Qt5::Widgets)
+else()
+  target_link_libraries(keepassx-autotype-test testautotype ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY})
+endif()

--- a/src/autotype/x11/AutoTypeX11.cpp
+++ b/src/autotype/x11/AutoTypeX11.cpp
@@ -552,7 +552,7 @@ int AutoTypePlatformX11::AddKeysym(KeySym keysym)
  */
 void AutoTypePlatformX11::SendEvent(XKeyEvent* event, int event_type)
 {
-    XSync(event->display, FALSE);
+    XSync(event->display, False);
     int (*oldHandler) (Display*, XErrorEvent*) = XSetErrorHandler(MyErrorHandler);
 
     event->type = event_type;
@@ -654,7 +654,7 @@ void AutoTypePlatformX11::SendKeyPressedEvent(KeySym keysym)
     event.y = 1;
     event.x_root = 1;
     event.y_root = 1;
-    event.same_screen = TRUE;
+    event.same_screen = True;
 
     Window root, child;
     int root_x, root_y, x, y;
@@ -720,5 +720,6 @@ int AutoTypePlatformX11::initialTimeout()
 {
     return 500;
 }
-
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
 Q_EXPORT_PLUGIN2(keepassx-autotype-x11, AutoTypePlatformX11)
+#endif

--- a/src/autotype/x11/AutoTypeX11.h
+++ b/src/autotype/x11/AutoTypeX11.h
@@ -39,7 +39,9 @@ class AutoTypePlatformX11 : public QObject, public AutoTypePlatformInterface
 {
     Q_OBJECT
     Q_INTERFACES(AutoTypePlatformInterface)
-
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+    Q_PLUGIN_METADATA(IID "org.keepassx.AutoTypePlatformInterface/1")
+#endif
 public:
     AutoTypePlatformX11();
     void unload() Q_DECL_OVERRIDE;

--- a/src/autotype/x11/CMakeLists.txt
+++ b/src/autotype/x11/CMakeLists.txt
@@ -8,10 +8,18 @@ set(autotype_X11_MOC
     AutoTypeX11.h
 )
 
-qt4_wrap_cpp(autotype_X11_SOURCES ${autotype_X11_MOC})
+if(USE_QT5)
+  qt5_wrap_cpp(autotype_X11_SOURCES ${autotype_X11_MOC})
+else()
+  qt4_wrap_cpp(autotype_X11_SOURCES ${autotype_X11_MOC})
+endif()
 
 add_library(keepassx-autotype-x11 MODULE ${autotype_X11_SOURCES})
-target_link_libraries(keepassx-autotype-x11 ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${X11_X11_LIB} ${X11_XTest_LIB})
+if(USE_QT5)
+  target_link_libraries(keepassx-autotype-x11 Qt5::Widgets Qt5::X11Extras ${X11_X11_LIB} ${X11_XTest_LIB})
+else()
+  target_link_libraries(keepassx-autotype-x11 ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${X11_X11_LIB} ${X11_XTest_LIB})
+endif()
 install(TARGETS keepassx-autotype-x11
         BUNDLE DESTINATION . COMPONENT Runtime
         LIBRARY DESTINATION ${PLUGIN_INSTALL_DIR} COMPONENT Runtime)

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -18,6 +18,7 @@
 #ifndef KEEPASSX_DATABASE_H
 #define KEEPASSX_DATABASE_H
 
+#include <QObject>
 #include <QDateTime>
 #include <QHash>
 

--- a/src/gui/SortFilterHideProxyModel.cpp
+++ b/src/gui/SortFilterHideProxyModel.cpp
@@ -36,3 +36,9 @@ bool SortFilterHideProxyModel::filterAcceptsColumn(int sourceColumn, const QMode
 
     return sourceColumn >= m_hiddenColumns.size() || !m_hiddenColumns.at(sourceColumn);
 }
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+Qt::DropActions SortFilterHideProxyModel::supportedDragActions() const
+{
+    return Qt::MoveAction | Qt::CopyAction;
+}
+#endif

--- a/src/gui/SortFilterHideProxyModel.h
+++ b/src/gui/SortFilterHideProxyModel.h
@@ -30,6 +30,9 @@ class SortFilterHideProxyModel : public QSortFilterProxyModel
 public:
     explicit SortFilterHideProxyModel(QObject* parent = Q_NULLPTR);
     void hideColumn(int column, bool hide);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+    Qt::DropActions supportedDragActions() const Q_DECL_OVERRIDE;
+#endif
 
 protected:
     bool filterAcceptsColumn(int sourceColumn, const QModelIndex& sourceParent) const Q_DECL_OVERRIDE;

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -594,7 +594,12 @@ void EditEntryWidget::insertAttachment()
 
     QString defaultDir = config()->get("LastAttachmentDir").toString();
     if (defaultDir.isEmpty() || !QDir(defaultDir).exists()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+        defaultDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+#else
         defaultDir = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
+#endif
+
     }
     QString filename = fileDialog()->getOpenFileName(this, tr("Select file"), defaultDir);
     if (filename.isEmpty() || !QFile::exists(filename)) {
@@ -628,7 +633,11 @@ void EditEntryWidget::saveCurrentAttachment()
     QString filename = m_attachmentsModel->keyByIndex(index);
     QString defaultDirName = config()->get("LastAttachmentDir").toString();
     if (defaultDirName.isEmpty() || !QDir(defaultDirName).exists()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+        defaultDirName = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+#else
         defaultDirName = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
+#endif
     }
     QDir dir(defaultDirName);
     QString savePath = fileDialog()->getSaveFileName(this, tr("Save attachment"),

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -29,7 +29,9 @@ EntryModel::EntryModel(QObject* parent)
     : QAbstractTableModel(parent)
     , m_group(Q_NULLPTR)
 {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
     setSupportedDragActions(Qt::MoveAction | Qt::CopyAction);
+#endif
 }
 
 Entry* EntryModel::entryFromIndex(const QModelIndex& index) const
@@ -182,7 +184,12 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
 
     return QVariant();
 }
-
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+Qt::DropActions EntryModel::supportedDragActions() const
+{
+    return Qt::MoveAction | Qt::CopyAction;
+}
+#endif
 Qt::DropActions EntryModel::supportedDropActions() const
 {
     return 0;

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -46,6 +46,9 @@ public:
     int columnCount(const QModelIndex& parent = QModelIndex()) const Q_DECL_OVERRIDE;
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+    Qt::DropActions supportedDragActions() const Q_DECL_OVERRIDE;
+#endif
     Qt::DropActions supportedDropActions() const Q_DECL_OVERRIDE;
     Qt::ItemFlags flags(const QModelIndex& modelIndex) const Q_DECL_OVERRIDE;
     QStringList mimeTypes() const Q_DECL_OVERRIDE;

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -32,7 +32,9 @@ EntryView::EntryView(QWidget* parent)
     m_sortModel->setDynamicSortFilter(true);
     m_sortModel->setSortLocaleAware(true);
     m_sortModel->setSortCaseSensitivity(Qt::CaseInsensitive);
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
     m_sortModel->setSupportedDragActions(m_model->supportedDragActions());
+#endif
     QTreeView::setModel(m_sortModel);
 
     setUniformRowHeights(true);

--- a/src/gui/group/GroupView.cpp
+++ b/src/gui/group/GroupView.cpp
@@ -19,6 +19,7 @@
 
 #include <QDragMoveEvent>
 #include <QMetaObject>
+#include <QMimeData>
 
 #include "core/Database.h"
 #include "core/Group.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,7 +55,11 @@ macro(add_unit_test)
   parse_arguments(TEST "NAME;SOURCES;MOCS;LIBS" "" ${ARGN})
   set(_test_NAME ${TEST_NAME})
   set(_srcList ${TEST_SOURCES})
+if(USE_QT5)
+  qt5_wrap_cpp(_srcList ${TEST_MOCS})
+else()
   qt4_wrap_cpp(_srcList ${TEST_MOCS})
+endif()
   add_executable(${_test_NAME} ${_srcList})
   target_link_libraries(${_test_NAME} ${TEST_LIBS})
 
@@ -86,6 +90,20 @@ macro(add_unit_test)
 endmacro(add_unit_test)
 
 
+if(USE_QT5)
+set(TEST_LIBRARIES
+    keepassx_core
+    Qt5::Core
+    Qt5::Widgets
+    Qt5::Test
+    ${GCRYPT_LIBRARIES}
+    ${ZLIB_LIBRARIES}
+)
+
+if(UNIX AND NOT APPLE)
+  set(TEST_LIBRARIES ${TEST_LIBRARIES} Qt5::DBus)
+endif()
+else()
 set(TEST_LIBRARIES
     keepassx_core
     ${QT_QTCORE_LIBRARY}
@@ -98,9 +116,13 @@ set(TEST_LIBRARIES
 if(UNIX AND NOT APPLE)
   set(TEST_LIBRARIES ${TEST_LIBRARIES} ${QT_QTDBUS_LIBRARY})
 endif()
-
+endif()
 set(modeltest_SOURCRS modeltest.cpp)
+if(USE_QT5)
+qt5_wrap_cpp(modeltest_SOURCRS modeltest.h)
+else()
 qt4_wrap_cpp(modeltest_SOURCRS modeltest.h)
+endif()
 add_library(modeltest STATIC ${modeltest_SOURCRS})
 
 add_unit_test(NAME testgroup SOURCES TestGroup.cpp MOCS TestGroup.h

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -16,9 +16,19 @@
 include_directories(../src)
 
 add_executable(kdbx-extract kdbx-extract.cpp)
+
+if(USE_QT5)
+target_link_libraries(kdbx-extract
+                      keepassx_core
+                      Qt5::Core
+                      Qt5::Widgets
+                      ${GCRYPT_LIBRARIES}
+                      ${ZLIB_LIBRARIES})
+else()
 target_link_libraries(kdbx-extract
                       keepassx_core
                       ${QT_QTCORE_LIBRARY}
                       ${QT_QTGUI_LIBRARY}
                       ${GCRYPT_LIBRARIES}
                       ${ZLIB_LIBRARIES})
+endif()


### PR DESCRIPTION
enable with cmake -DUSE_QT5=ON
This does currently only work for Linux
I've not tested on other systems, but most likely some more cmake stuff has to be changed
I'm no cmake expert, so there may be some parts that can be made easier...