### PR TITLE
Fix the temporary filename template for an attachment

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -661,7 +661,7 @@ void EditEntryWidget::openAttachment(const QModelIndex& index)
     QByteArray attachmentData = m_entryAttachments->value(filename);
 
     // tmp file will be removed once the database (or the application) has been closed
-    QString tmpFileTemplate = QDir::temp().absoluteFilePath(filename);
+    QString tmpFileTemplate = QDir::temp().absoluteFilePath(QString("XXXXXX.").append(filename));
     QTemporaryFile* file = new QTemporaryFile(tmpFileTemplate, this);
 
     if (!file->open()) {


### PR DESCRIPTION
Currently a temporary filename is suffixed with an auto-generated random string due to lack of the `XXXXXX` part in `tmpFileTemplate`, which makes the OS unable to determine the application to open the file. (at least on OS X)

This patch makes QTemporaryFile prefix the temporary filename with a random string preserving the original suffix of an attachment to help the OS invoke the correct application associated with the file type.
