### PR TITLE
Improve UI of the search edit.

### DIFF
--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -102,6 +102,9 @@ Q_SIGNALS:
     void splitterSizesChanged();
     void entryColumnSizesChanged();
 
+protected:
+    bool eventFilter(QObject* object, QEvent* event);
+
 public Q_SLOTS:
     void createEntry();
     void cloneEntry();

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -210,6 +210,10 @@ void TestGui::testSearch()
     // Search for "some"
     QTest::keyClicks(searchEdit, "some");
     QTRY_COMPARE(entryView->model()->rowCount(), 4);
+    // Press Down to focus on the entry view
+    QVERIFY(!entryView->hasFocus());
+    QTest::keyClick(searchEdit, Qt::Key_Down);
+    QVERIFY(entryView->hasFocus());
 
     clickIndex(entryView->model()->index(0, 1), entryView, Qt::LeftButton);
     QAction* entryEditAction = m_mainWindow->findChild<QAction*>("actionEntryEdit");


### PR DESCRIPTION
- The copy action (Control+C) when no text is selected copies the password of the current entry.  This should be reasonable when Control+B copies the username.

- Down at EOL moves the focus to the entry view.  Enter and Tab should do that, but it would be handy for user to be able to get to the third entry by hitting Down three times.