### PR TITLE
support to import Firefox passwords

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,6 +62,7 @@ set(keepassx_SOURCES
     crypto/SymmetricCipherGcrypt.cpp
     format/KeePass1.h
     format/KeePass1Reader.cpp
+    format/FirefoxPwEReader.cpp
     format/KeePass2.h
     format/KeePass2RandomStream.cpp
     format/KeePass2Reader.cpp
@@ -85,6 +86,7 @@ set(keepassx_SOURCES
     gui/FileDialog.cpp
     gui/IconModels.cpp
     gui/KeePass1OpenWidget.cpp
+    gui/FirefoxPwEOpenWidget.cpp
     gui/LineEdit.cpp
     gui/MainWindow.cpp
     gui/MessageBox.cpp
@@ -166,6 +168,7 @@ set(keepassx_MOC
     gui/EditWidgetProperties.h
     gui/IconModels.h
     gui/KeePass1OpenWidget.h
+    gui/FirefoxPwEOpenWidget.h
     gui/LineEdit.h
     gui/MainWindow.h
     gui/PasswordEdit.h

--- a/src/format/FirefoxPwEReader.cpp
+++ b/src/format/FirefoxPwEReader.cpp
@@ -1,0 +1,204 @@
+/*
+ *  Copyright (C) 2014 Karsten Hinz <k.hinz@tu-bs.de>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "FirefoxPwEReader.h"
+
+#include <QFile>
+#include <QDebug>
+#include <QTextCodec>
+#include <QByteArray>
+#include <QXmlStreamReader>
+
+#include "core/Database.h"
+#include "core/Endian.h"
+#include "core/Entry.h"
+#include "core/Group.h"
+
+// A Reader for files from this software 
+// https://addons.mozilla.org/de/firefox/addon/password-exporter/
+// recommended to use the base64 export to xml
+
+FirefoxPwEReader::FirefoxPwEReader()
+    : m_error(false)
+{
+}
+
+bool FirefoxPwEReader::hasError()
+{
+    return m_error;
+}
+
+QList<Entry*> FirefoxPwEReader::parseXml(QIODevice* device) {
+    QList<Entry*> entries;
+
+    /* fill list of entries */
+    m_xml.clear();
+    m_xml.setDevice(device);
+
+    bool encoded = false;
+    bool acceptedVersion = false; //Version 1.1
+
+    while ((!m_xml.atEnd()&&!m_xml.hasError()))
+    {
+        /* Read next element.*/
+        QXmlStreamReader::TokenType token = m_xml.readNext();
+        if(token == QXmlStreamReader::StartDocument)
+        {
+            continue;
+        }
+        if(token == QXmlStreamReader::StartElement) {
+            /* If it's the list start, we'll check attributes to skip parsing on unsupported version.*/
+            if(m_xml.name() == "entries") {
+
+                QXmlStreamAttributes attributes = m_xml.attributes();
+                encoded = (attributes.value("encrypt").compare("true", Qt::CaseInsensitive)==0);
+                acceptedVersion =
+                    (attributes.value("extxmlversion").compare("1.1", Qt::CaseInsensitive)==0)&&
+                    (attributes.value("ext").compare("Password Exporter", Qt::CaseInsensitive)==0);
+
+                if (encoded)
+                    qDebug() << "encoded";
+                else
+                    qDebug() << "uncoded";
+
+                if (!acceptedVersion) {
+                    qDebug() << "not a supported Firefox Addon Password Exporter file";
+                    m_xml.skipCurrentElement();
+                }
+                continue;
+            }
+            if(m_xml.name() == "entry") {
+                entries.append(this->parseXmlEntry(m_xml,encoded));
+            }
+        }
+    }
+    /* Error handling. */
+    if (m_xml.hasError())
+    {
+        qWarning() <<  QObject::tr("%1\nLine %2, column %3")
+            .arg(m_xml.errorString())
+            .arg(m_xml.lineNumber())
+            .arg(m_xml.columnNumber());
+        QString e_msg = "Error: Import incomplete - try different export option to create password file";
+        qCritical() << e_msg;
+        raiseError(e_msg);
+    }
+    /* Removes any device() or data from the reader
+     * and resets its internal state to the initial state. */
+    m_xml.clear();
+
+    return entries;
+}
+
+Database* FirefoxPwEReader::readDatabase(QIODevice* device, QString password)
+{
+    m_error = false;
+    m_errorStr.clear();
+
+    QScopedPointer<Database> db(new Database());
+    m_db = db.data();
+    m_device = device;
+
+    //TODO check csv or xml
+    bool xmlNotCsv = true;
+
+
+    QList<Entry*> entries;
+    if (xmlNotCsv) {
+        entries = parseXml(device);
+    }
+    //else{
+        //TODO parse CSV
+    //}
+
+
+    Q_FOREACH (Entry* entry, entries) {
+        entry->setUuid(Uuid::random());
+    }
+
+    db->rootGroup()->setName(tr("Root"));
+
+    Q_FOREACH (Entry* entry, m_db->rootGroup()->entriesRecursive()) {
+        entry->setUpdateTimeinfo(true);
+    }
+
+    return db.take();
+}
+
+Entry* FirefoxPwEReader::parseXmlEntry(QXmlStreamReader& xml, bool encoded)
+{
+    QScopedPointer<Entry> entry(new Entry());
+    entry->setUpdateTimeinfo(false);
+    entry->setGroup(m_db->rootGroup());
+
+    TimeInfo timeInfo;
+
+    /* Let's get the attributes for entry */
+    QXmlStreamAttributes attributes = xml.attributes();
+    entry->setTitle(attributes.value("host").toString());
+    entry->setUrl(attributes.value("host").toString());
+
+    QString username = attributes.value("user").toString();
+    QString password = attributes.value("password").toString();
+
+    if (encoded) {
+        //decode user name and password
+        QTextCodec *codec = QTextCodec::codecForName("UTF-16");
+        QTextEncoder *encoderWithoutBom = codec->makeEncoder( QTextCodec::IgnoreHeader );
+
+        QByteArray ba = encoderWithoutBom->fromUnicode(username);
+        username = QByteArray::fromBase64(ba);
+        ba = encoderWithoutBom->fromUnicode(password);
+        password = QByteArray::fromBase64(ba);
+    }
+    entry->setUsername(username);
+    entry->setPassword(password);
+    QString note =
+        "userFieldName: " + attributes.value("password").toString() + "\n" +
+        "passFieldName: " + attributes.value("passFieldName").toString() + "\n" +
+        "formSubmitURL: " + attributes.value("formSubmitURL").toString() + "\n" +
+        "httpRealm: " + attributes.value("httpRealm").toString() + "\n";
+    entry->setNotes(note);
+
+    QDateTime dateTime = QDateTime::currentDateTime();
+    timeInfo.setExpires(false);
+
+    if (dateTime.isValid()) {
+        timeInfo.setLastAccessTime(dateTime);
+    }
+    if (dateTime.isValid()) {
+        timeInfo.setLastModificationTime(dateTime);
+    }
+    if (dateTime.isValid()) {
+        timeInfo.setCreationTime(dateTime);
+    }
+    entry->setTimeInfo(timeInfo);
+
+    return entry.take();
+}
+
+void FirefoxPwEReader::raiseError(const QString& errorMessage)
+{
+    m_error = true;
+    m_errorStr = errorMessage;
+}
+
+QString FirefoxPwEReader::errorString()
+{
+    return m_errorStr;
+}
+

--- a/src/format/FirefoxPwEReader.h
+++ b/src/format/FirefoxPwEReader.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2014 Karsten Hinz <k.hinz@tu-bs.de>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSX_FIREFOXPWEREADER_H
+#define KEEPASSX_FIREFOXPWEREADER_H
+
+#include <QCoreApplication>
+#include <QXmlStreamReader>
+#include <QDateTime>
+#include <QHash>
+
+class Database;
+class Entry;
+class Group;
+class QIODevice;
+
+class FirefoxPwEReader
+{
+    Q_DECLARE_TR_FUNCTIONS(FirefoxPwEReader)
+
+public:
+    FirefoxPwEReader();
+    Database* readDatabase(QIODevice* device, QString password);
+    bool hasError();
+    QString errorString();
+
+private:
+    Entry* parseXmlEntry(QXmlStreamReader& xml, bool encrypted);
+    QList<Entry*> parseXml(QIODevice* device);
+    void raiseError(const QString& errorMessage);
+
+    Database* m_db;
+    QIODevice* m_device;
+    QXmlStreamReader m_xml;
+
+    bool m_error;
+    QString m_errorStr;
+};
+
+#endif // KEEPASSX_FIREFOXPWEREADER_H

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -181,6 +181,25 @@ void DatabaseTabWidget::importKeePass1Database()
     dbStruct.dbWidget->switchToImportKeepass1(fileName);
 }
 
+void DatabaseTabWidget::importFirefoxPwExport()
+{
+    QString fileName = fileDialog()->getOpenFileName(this, tr("Open Password file exported by Firefox Addon 'Password Exporter'"), QString(),
+            tr("Password XML") + " (*.xml);;" + tr("All files (*)"));
+
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    Database* db = new Database();
+    DatabaseManagerStruct dbStruct;
+    dbStruct.dbWidget = new DatabaseWidget(db, this);
+    dbStruct.modified = true;
+
+    insertDatabase(db, dbStruct);
+
+    dbStruct.dbWidget->switchToImportFirefoxPwExport(fileName);
+}
+
 bool DatabaseTabWidget::closeDatabase(Database* db)
 {
     Q_ASSERT(db);

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -62,6 +62,7 @@ public Q_SLOTS:
     void newDatabase();
     void openDatabase();
     void importKeePass1Database();
+    void importFirefoxPwExport();
     void saveDatabase(int index = -1);
     void saveDatabaseAs(int index = -1);
     bool closeDatabase(int index = -1);

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -38,6 +38,7 @@
 #include "gui/DatabaseOpenWidget.h"
 #include "gui/DatabaseSettingsWidget.h"
 #include "gui/KeePass1OpenWidget.h"
+#include "gui/FirefoxPwEOpenWidget.h"
 #include "gui/MessageBox.h"
 #include "gui/UnlockDatabaseWidget.h"
 #include "gui/entry/EditEntryWidget.h"
@@ -125,6 +126,8 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     m_databaseOpenWidget->setObjectName("databaseOpenWidget");
     m_keepass1OpenWidget = new KeePass1OpenWidget();
     m_keepass1OpenWidget->setObjectName("keepass1OpenWidget");
+    m_firefoxPwEOpenWidget = new FirefoxPwEOpenWidget();
+    m_firefoxPwEOpenWidget->setObjectName("FirefoxPwEOpenWidget");
     m_unlockDatabaseWidget = new UnlockDatabaseWidget();
     m_unlockDatabaseWidget->setObjectName("unlockDatabaseWidget");
     addWidget(m_mainWidget);
@@ -135,6 +138,7 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     addWidget(m_historyEditEntryWidget);
     addWidget(m_databaseOpenWidget);
     addWidget(m_keepass1OpenWidget);
+    addWidget(m_firefoxPwEOpenWidget);
     addWidget(m_unlockDatabaseWidget);
 
     connect(m_splitter, SIGNAL(splitterMoved(int,int)), SIGNAL(splitterSizesChanged()));
@@ -153,6 +157,7 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     connect(m_databaseSettingsWidget, SIGNAL(editFinished(bool)), SLOT(switchToView(bool)));
     connect(m_databaseOpenWidget, SIGNAL(editFinished(bool)), SLOT(openDatabase(bool)));
     connect(m_keepass1OpenWidget, SIGNAL(editFinished(bool)), SLOT(openDatabase(bool)));
+    connect(m_firefoxPwEOpenWidget, SIGNAL(editFinished(bool)), SLOT(openDatabase(bool)));
     connect(m_unlockDatabaseWidget, SIGNAL(editFinished(bool)), SLOT(unlockDatabase(bool)));
     connect(this, SIGNAL(currentChanged(int)), this, SLOT(emitCurrentModeChanged()));
     connect(m_searchUi->searchEdit, SIGNAL(textChanged(QString)), this, SLOT(startSearchTimer()));
@@ -617,6 +622,8 @@ void DatabaseWidget::openDatabase(bool accepted)
         m_databaseOpenWidget = Q_NULLPTR;
         delete m_keepass1OpenWidget;
         m_keepass1OpenWidget = Q_NULLPTR;
+        delete m_firefoxPwEOpenWidget;
+        m_firefoxPwEOpenWidget = Q_NULLPTR;
     }
     else {
         if (m_databaseOpenWidget->database()) {
@@ -700,6 +707,13 @@ void DatabaseWidget::switchToImportKeepass1(const QString& fileName)
     updateFilename(fileName);
     m_keepass1OpenWidget->load(fileName);
     setCurrentWidget(m_keepass1OpenWidget);
+}
+
+void DatabaseWidget::switchToImportFirefoxPwExport(const QString& fileName)
+{
+    updateFilename(fileName);
+    m_firefoxPwEOpenWidget->load(fileName);
+    setCurrentWidget(m_firefoxPwEOpenWidget);
 }
 
 void DatabaseWidget::openSearch()

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -36,6 +36,7 @@ class EntryView;
 class Group;
 class GroupView;
 class KeePass1OpenWidget;
+class FirefoxPwEOpenWidget;
 class QFile;
 class QMenu;
 class QSplitter;
@@ -117,6 +118,7 @@ public Q_SLOTS:
     void switchToOpenDatabase(const QString& fileName);
     void switchToOpenDatabase(const QString& fileName, const QString& password, const QString& keyFile);
     void switchToImportKeepass1(const QString& fileName);
+    void switchToImportFirefoxPwExport(const QString& fileName);
     void openSearch();
 
 private Q_SLOTS:
@@ -155,6 +157,7 @@ private:
     DatabaseSettingsWidget* m_databaseSettingsWidget;
     DatabaseOpenWidget* m_databaseOpenWidget;
     KeePass1OpenWidget* m_keepass1OpenWidget;
+    FirefoxPwEOpenWidget* m_firefoxPwEOpenWidget;
     UnlockDatabaseWidget* m_unlockDatabaseWidget;
     QSplitter* m_splitter;
     GroupView* m_groupView;

--- a/src/gui/FirefoxPwEOpenWidget.cpp
+++ b/src/gui/FirefoxPwEOpenWidget.cpp
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2014 Karsten Hinz <k.hinz@tu-bs.de>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "FirefoxPwEOpenWidget.h"
+
+#include <QFile>
+#include <QFileInfo>
+
+#include "ui_DatabaseOpenWidget.h"
+#include "core/Database.h"
+#include "core/Metadata.h"
+#include "core/Entry.h"
+#include "core/Group.h"
+#include "format/FirefoxPwEReader.h"
+#include "gui/MessageBox.h"
+
+FirefoxPwEOpenWidget::FirefoxPwEOpenWidget(QWidget* parent)
+    : DatabaseOpenWidget(parent)
+{
+    m_ui->labelHeadline->setText(tr("Import Password file exported by Firefox Addon 'Password Exporter'"));
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
+    m_ui->comboKeyFile->setEnabled(false);
+    m_ui->checkKeyFile->setEnabled(false);
+    m_ui->checkPassword->setEnabled(false);
+    m_ui->buttonBrowseFile->setEnabled(false);
+    m_ui->editPassword->setEnabled(false);
+}
+
+
+void FirefoxPwEOpenWidget::openDatabase()
+{
+
+    FirefoxPwEReader reader;
+
+    QString password;
+
+    if (m_ui->checkPassword->isChecked()) {
+        password = m_ui->editPassword->text();
+    }
+
+    QFile file(m_filename);
+    if (!file.open(QIODevice::ReadOnly)) {
+        // TODO: error message
+        return;
+    }
+    if (m_db) {
+        delete m_db;
+    }
+    QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+
+    // get database
+    Database* db = reader.readDatabase(&file, password);
+
+    if (!reader.hasError()) {
+        m_db = db;
+    }
+
+    //continue
+    QApplication::restoreOverrideCursor();
+
+    if (m_db) {
+        m_db->metadata()->setName(QFileInfo(m_filename).completeBaseName());
+        Q_EMIT editFinished(true);
+    }
+    else {
+        MessageBox::warning(this, tr("Error"), tr("Unable to open the database.").append("\n")
+                .append(reader.errorString()));
+        m_ui->editPassword->clear();
+    }
+}

--- a/src/gui/FirefoxPwEOpenWidget.h
+++ b/src/gui/FirefoxPwEOpenWidget.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2014 Karsten Hinz <k.hinz@tu-bs.de>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSX_FIREFOXPWEOPENWIDGET_H
+#define KEEPASSX_FIREFOXPWEOPENWIDGET_H
+
+#include <QCoreApplication>
+#include "gui/DatabaseOpenWidget.h"
+
+class FirefoxPwEOpenWidget : public DatabaseOpenWidget
+{
+    Q_OBJECT
+
+public:
+    explicit FirefoxPwEOpenWidget(QWidget* parent = Q_NULLPTR);
+
+protected:
+    void openDatabase() Q_DECL_OVERRIDE;
+};
+
+#endif // KEEPASSX_FIREFOXPWEOPENWIDGET_H

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -161,6 +161,8 @@ MainWindow::MainWindow()
             SLOT(changeDatabaseSettings()));
     connect(m_ui->actionImportKeePass1, SIGNAL(triggered()), m_ui->tabWidget,
             SLOT(importKeePass1Database()));
+    connect(m_ui->actionImportFirefoxPwExport, SIGNAL(triggered()), m_ui->tabWidget,
+            SLOT(importFirefoxPwExport()));
     connect(m_ui->actionLockDatabases, SIGNAL(triggered()), m_ui->tabWidget,
             SLOT(lockDatabases()));
     connect(m_ui->actionQuit, SIGNAL(triggered()), SLOT(close()));
@@ -359,6 +361,7 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
     m_ui->actionDatabaseOpen->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
     m_ui->menuRecentDatabases->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
     m_ui->actionImportKeePass1->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
+    m_ui->actionImportFirefoxPwExport->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
 
     m_ui->actionLockDatabases->setEnabled(m_ui->tabWidget->hasLockableDatabases());
 }

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -93,6 +93,7 @@
     <addaction name="actionChangeDatabaseSettings"/>
     <addaction name="separator"/>
     <addaction name="actionImportKeePass1"/>
+    <addaction name="actionImportFirefoxPwExport"/>
     <addaction name="separator"/>
     <addaction name="actionLockDatabases"/>
     <addaction name="actionQuit"/>
@@ -293,6 +294,11 @@
   <action name="actionImportKeePass1">
    <property name="text">
     <string>Import KeePass 1 database</string>
+   </property>
+  </action>
+  <action name="actionImportFirefoxPwExport">
+   <property name="text">
+    <string>Import from Firefox Addon 'Password Exporter'</string>
    </property>
   </action>
   <action name="actionEntryClone">


### PR DESCRIPTION
The Firefox Addon "Password Exporter"  https://addons.mozilla.org/en-US/firefox/addon/password-exporter/
proviedes the stored Firefox Passwords as csv or xml, with plain or base64 encodes values.

This PR adds support to import a xml with plain or base64 encoded passwords. (without base64 it's possible to breaks the xml import by special chars in passwords like '$' ).
