### PR TITLE
Replace message dialogs with inline messages (KMessageWidget)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,9 +85,11 @@ set(keepassx_SOURCES
     gui/FileDialog.cpp
     gui/IconModels.cpp
     gui/KeePass1OpenWidget.cpp
+    gui/kmessagewidget.cpp
     gui/LineEdit.cpp
     gui/MainWindow.cpp
     gui/MessageBox.cpp
+    gui/MessageWidget.cpp
     gui/PasswordEdit.cpp
     gui/PasswordGeneratorWidget.cpp
     gui/PasswordComboBox.cpp
@@ -166,8 +168,10 @@ set(keepassx_MOC
     gui/EditWidgetProperties.h
     gui/IconModels.h
     gui/KeePass1OpenWidget.h
+    gui/kmessagewidget.h
     gui/LineEdit.h
     gui/MainWindow.h
+    gui/MessageWidget.h
     gui/PasswordEdit.h
     gui/PasswordGeneratorWidget.h
     gui/PasswordComboBox.h

--- a/src/gui/ChangeMasterKeyWidget.cpp
+++ b/src/gui/ChangeMasterKeyWidget.cpp
@@ -30,6 +30,8 @@ ChangeMasterKeyWidget::ChangeMasterKeyWidget(QWidget* parent)
 {
     m_ui->setupUi(this);
 
+    m_ui->messageWidget->setHidden(true);
+
     connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(generateKey()));
     connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(reject()));
     m_ui->togglePasswordButton->setIcon(filePath()->onOffIcon("actions", "password-show"));
@@ -52,7 +54,7 @@ void ChangeMasterKeyWidget::createKeyFile()
         QString errorMsg;
         bool created = FileKey::create(fileName, &errorMsg);
         if (!created) {
-            MessageBox::warning(this, tr("Error"), tr("Unable to create Key File : ") + errorMsg);
+            m_ui->messageWidget->showMessageError(tr("Unable to create Key File : ").append(errorMsg));
         }
         else {
             m_ui->keyFileCombo->setEditText(fileName);
@@ -110,7 +112,7 @@ void ChangeMasterKeyWidget::generateKey()
             m_key.addKey(PasswordKey(m_ui->enterPasswordEdit->text()));
         }
         else {
-            MessageBox::warning(this, tr("Error"), tr("Different passwords supplied."));
+            m_ui->messageWidget->showMessageError(tr("Different passwords supplied."));
             m_ui->enterPasswordEdit->setText("");
             m_ui->repeatPasswordEdit->setText("");
             return;

--- a/src/gui/ChangeMasterKeyWidget.cpp
+++ b/src/gui/ChangeMasterKeyWidget.cpp
@@ -121,8 +121,11 @@ void ChangeMasterKeyWidget::generateKey()
     if (m_ui->keyFileGroup->isChecked()) {
         FileKey fileKey;
         QString errorMsg;
-        if (!fileKey.load(m_ui->keyFileCombo->currentText(), &errorMsg)) {
-            // TODO: error handling
+        QString fileKeyName = m_ui->keyFileCombo->currentText();
+        if (!fileKey.load(fileKeyName, &errorMsg)) {
+            m_ui->messageWidget->showMessageError(tr("Unable to load Key File : ")
+                                                  .append(fileKeyName).append("\n").append(errorMsg));
+            return;
         }
         m_key.addKey(fileKey);
     }

--- a/src/gui/ChangeMasterKeyWidget.cpp
+++ b/src/gui/ChangeMasterKeyWidget.cpp
@@ -54,7 +54,7 @@ void ChangeMasterKeyWidget::createKeyFile()
         QString errorMsg;
         bool created = FileKey::create(fileName, &errorMsg);
         if (!created) {
-            m_ui->messageWidget->showMessageError(tr("Unable to create Key File : ").append(errorMsg));
+            m_ui->messageWidget->showMessage(tr("Unable to create Key File : ").append(errorMsg), MessageWidget::Error);
         }
         else {
             m_ui->keyFileCombo->setEditText(fileName);
@@ -112,7 +112,7 @@ void ChangeMasterKeyWidget::generateKey()
             m_key.addKey(PasswordKey(m_ui->enterPasswordEdit->text()));
         }
         else {
-            m_ui->messageWidget->showMessageError(tr("Different passwords supplied."));
+            m_ui->messageWidget->showMessage(tr("Different passwords supplied."), MessageWidget::Error);
             m_ui->enterPasswordEdit->setText("");
             m_ui->repeatPasswordEdit->setText("");
             return;
@@ -123,13 +123,14 @@ void ChangeMasterKeyWidget::generateKey()
         QString errorMsg;
         QString fileKeyName = m_ui->keyFileCombo->currentText();
         if (!fileKey.load(fileKeyName, &errorMsg)) {
-            m_ui->messageWidget->showMessageError(tr("Unable to load Key File : ")
-                                                  .append(fileKeyName).append("\n").append(errorMsg));
+            m_ui->messageWidget->showMessage(tr("Unable to load Key File : ")
+                                             .append(fileKeyName).append("\n").append(errorMsg), MessageWidget::Error);
             return;
         }
         m_key.addKey(fileKey);
     }
 
+    m_ui->messageWidget->hideMessage();
     Q_EMIT editFinished(true);
 }
 

--- a/src/gui/ChangeMasterKeyWidget.ui
+++ b/src/gui/ChangeMasterKeyWidget.ui
@@ -7,10 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>438</width>
-    <height>249</height>
+    <height>342</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="MessageWidget" name="messageWidget" native="true"/>
+   </item>
    <item>
     <widget class="QLabel" name="headlineLabel"/>
    </item>
@@ -150,6 +153,12 @@
    <class>PasswordEdit</class>
    <extends>QLineEdit</extends>
    <header>gui/PasswordEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>MessageWidget</class>
+   <extends>QWidget</extends>
+   <header>gui/MessageWidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -105,8 +105,8 @@ void DatabaseOpenWidget::openDatabase()
 
     QFile file(m_filename);
     if (!file.open(QIODevice::ReadOnly)) {
-        m_ui->messageWidget->showMessageError(tr("Unable to read file.")
-                                              .append("\n").append(file.errorString()));
+        m_ui->messageWidget->showMessage(tr("Unable to read file.")
+                                         .append("\n").append(file.errorString()), MessageWidget::Error);
         return;
     }
     if (m_db) {
@@ -123,8 +123,8 @@ void DatabaseOpenWidget::openDatabase()
         Q_EMIT editFinished(true);
     }
     else {
-        m_ui->messageWidget->showMessageError(tr("Unable to open the database.")
-                                              .append("\n").append(reader.errorString()));
+        m_ui->messageWidget->showMessage(tr("Unable to open the database.")
+                                         .append("\n").append(reader.errorString()), MessageWidget::Error);
         m_ui->editPassword->clear();
     }
 }
@@ -144,7 +144,8 @@ CompositeKey DatabaseOpenWidget::databaseKey()
         QString keyFilename = m_ui->comboKeyFile->currentText();
         QString errorMsg;
         if (!key.load(keyFilename, &errorMsg)) {
-            m_ui->messageWidget->showMessageError(tr("Can't open key file").append(":\n").append(errorMsg));
+            m_ui->messageWidget->showMessage(tr("Can't open key file").append(":\n")
+                                             .append(errorMsg), MessageWidget::Error);
             return CompositeKey();
         }
         masterKey.addKey(key);

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -34,6 +34,8 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
 {
     m_ui->setupUi(this);
 
+    m_ui->messageWidget->setHidden(true);
+
     QFont font = m_ui->labelHeadline->font();
     font.setBold(true);
     font.setPointSize(font.pointSize() + 2);
@@ -103,7 +105,8 @@ void DatabaseOpenWidget::openDatabase()
 
     QFile file(m_filename);
     if (!file.open(QIODevice::ReadOnly)) {
-        // TODO: error message
+        m_ui->messageWidget->showMessageError(tr("Unable to read file.")
+                                              .append("\n").append(file.errorString()));
         return;
     }
     if (m_db) {
@@ -114,11 +117,14 @@ void DatabaseOpenWidget::openDatabase()
     QApplication::restoreOverrideCursor();
 
     if (m_db) {
+        if (m_ui->messageWidget->isVisible()) {
+            m_ui->messageWidget->animatedHide();
+        }
         Q_EMIT editFinished(true);
     }
     else {
-        MessageBox::warning(this, tr("Error"), tr("Unable to open the database.").append("\n")
-                            .append(reader.errorString()));
+        m_ui->messageWidget->showMessageError(tr("Unable to open the database.")
+                                              .append("\n").append(reader.errorString()));
         m_ui->editPassword->clear();
     }
 }
@@ -138,7 +144,7 @@ CompositeKey DatabaseOpenWidget::databaseKey()
         QString keyFilename = m_ui->comboKeyFile->currentText();
         QString errorMsg;
         if (!key.load(keyFilename, &errorMsg)) {
-            MessageBox::warning(this, tr("Error"), tr("Can't open key file").append(":\n").append(errorMsg));
+            m_ui->messageWidget->showMessageError(tr("Can't open key file").append(":\n").append(errorMsg));
             return CompositeKey();
         }
         masterKey.addKey(key);

--- a/src/gui/DatabaseOpenWidget.ui
+++ b/src/gui/DatabaseOpenWidget.ui
@@ -10,10 +10,13 @@
     <height>250</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,0,1,0,0,3">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0,0,1,0,0,3">
    <property name="spacing">
     <number>8</number>
    </property>
+   <item>
+    <widget class="MessageWidget" name="messageWidget" native="true"/>
+   </item>
    <item>
     <spacer name="verticalSpacer_2">
      <property name="orientation">
@@ -143,6 +146,12 @@
    <class>PasswordEdit</class>
    <extends>QLineEdit</extends>
    <header>gui/PasswordEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>MessageWidget</class>
+   <extends>QWidget</extends>
+   <header>gui/MessageWidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -23,11 +23,13 @@
 
 #include "format/KeePass2Writer.h"
 #include "gui/DatabaseWidget.h"
+#include "gui/MessageWidget.h"
 
 class DatabaseWidget;
 class DatabaseWidgetStateSync;
 class DatabaseOpenWidget;
 class QFile;
+class MessageWidget;
 
 struct DatabaseManagerStruct
 {
@@ -77,6 +79,10 @@ Q_SIGNALS:
     void tabNameChanged();
     void databaseWithFileClosed(QString filePath);
     void activateDatabaseChanged(DatabaseWidget* dbWidget);
+    void messageGlobal(const QString&, MessageWidget::MessageType type);
+    void messageTab(const QString&, MessageWidget::MessageType type);
+    void messageDismissGlobal();
+    void messageDismissTab();
 
 private Q_SLOTS:
     void updateTabName(Database* db);

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -60,7 +60,14 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     m_searchTimer->setSingleShot(true);
 
     m_mainWidget = new QWidget(this);
-    QLayout* layout = new QHBoxLayout(m_mainWidget);
+
+    m_messageWidget = new MessageWidget(this);
+    m_messageWidget->setHidden(true);
+
+    QVBoxLayout* mainLayout = new QVBoxLayout();
+    QLayout* layout = new QHBoxLayout();
+    mainLayout->addWidget(m_messageWidget);
+    mainLayout->addLayout(layout);
     m_splitter = new QSplitter(m_mainWidget);
     m_splitter->setChildrenCollapsible(false);
 
@@ -106,7 +113,7 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     m_splitter->setStretchFactor(1, 70);
 
     layout->addWidget(m_splitter);
-    m_mainWidget->setLayout(layout);
+    m_mainWidget->setLayout(mainLayout);
 
     m_editEntryWidget = new EditEntryWidget();
     m_editEntryWidget->setObjectName("editEntryWidget");
@@ -883,4 +890,16 @@ QStringList DatabaseWidget::customEntryAttributes() const
 bool DatabaseWidget::isGroupSelected() const
 {
     return m_groupView->currentGroup() != Q_NULLPTR;
+}
+
+void DatabaseWidget::showMessage(const QString& text, MessageWidget::MessageType type)
+{
+    m_messageWidget->showMessage(text, type);
+}
+
+void DatabaseWidget::hideMessage()
+{
+    if (m_messageWidget->isVisible()) {
+        m_messageWidget->animatedHide();
+    }
 }

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -24,6 +24,7 @@
 #include "core/Global.h"
 
 #include "gui/entry/EntryModel.h"
+#include "gui/MessageWidget.h"
 
 class ChangeMasterKeyWidget;
 class DatabaseOpenWidget;
@@ -40,6 +41,7 @@ class QFile;
 class QMenu;
 class QSplitter;
 class UnlockDatabaseWidget;
+class MessageWidget;
 
 namespace Ui {
     class SearchWidget;
@@ -118,6 +120,8 @@ public Q_SLOTS:
     void switchToOpenDatabase(const QString& fileName, const QString& password, const QString& keyFile);
     void switchToImportKeepass1(const QString& fileName);
     void openSearch();
+    void showMessage(const QString& text, MessageWidget::MessageType type);
+    void hideMessage();
 
 private Q_SLOTS:
     void entryActivationSignalReceived(Entry* entry, EntryModel::ModelColumn column);
@@ -166,6 +170,7 @@ private:
     QTimer* m_searchTimer;
     QWidget* m_widgetBeforeLock;
     QString m_filename;
+    MessageWidget* m_messageWidget;
 };
 
 #endif // KEEPASSX_DATABASEWIDGET_H

--- a/src/gui/DatabaseWidgetStateSync.cpp
+++ b/src/gui/DatabaseWidgetStateSync.cpp
@@ -152,3 +152,4 @@ QVariant DatabaseWidgetStateSync::intListToVariant(const QList<int>& list)
 
     return result;
 }
+

--- a/src/gui/EditWidget.cpp
+++ b/src/gui/EditWidget.cpp
@@ -24,6 +24,8 @@ EditWidget::EditWidget(QWidget* parent)
 {
     m_ui->setupUi(this);
 
+    m_ui->messageWidget->setHidden(true);
+
     QFont headerLabelFont = m_ui->headerLabel->font();
     headerLabelFont.setBold(true);
     headerLabelFont.setPointSize(headerLabelFont.pointSize() + 2);
@@ -67,4 +69,26 @@ void EditWidget::setHeadline(const QString& text)
 QLabel* EditWidget::headlineLabel()
 {
     return m_ui->headerLabel;
+}
+
+void EditWidget::showMessageError(const QString& text)
+{
+    m_ui->messageWidget->showMessageError(text);
+}
+
+void EditWidget::showMessageWarning(const QString& text)
+{
+    m_ui->messageWidget->showMessageWarning(text);
+}
+
+void EditWidget::showMessageInformation(const QString& text)
+{
+    m_ui->messageWidget->showMessageInformation(text);
+}
+
+void EditWidget::hideMessage()
+{
+    if (m_ui->messageWidget->isVisible()) {
+        m_ui->messageWidget->animatedHide();
+    }
 }

--- a/src/gui/EditWidget.cpp
+++ b/src/gui/EditWidget.cpp
@@ -71,19 +71,9 @@ QLabel* EditWidget::headlineLabel()
     return m_ui->headerLabel;
 }
 
-void EditWidget::showMessageError(const QString& text)
+void EditWidget::showMessage(const QString& text, MessageWidget::MessageType type)
 {
-    m_ui->messageWidget->showMessageError(text);
-}
-
-void EditWidget::showMessageWarning(const QString& text)
-{
-    m_ui->messageWidget->showMessageWarning(text);
-}
-
-void EditWidget::showMessageInformation(const QString& text)
-{
-    m_ui->messageWidget->showMessageInformation(text);
+    m_ui->messageWidget->showMessage(text, type);
 }
 
 void EditWidget::hideMessage()

--- a/src/gui/EditWidget.h
+++ b/src/gui/EditWidget.h
@@ -21,6 +21,7 @@
 #include <QScopedPointer>
 
 #include "gui/DialogyWidget.h"
+#include "gui/MessageWidget.h"
 
 class QLabel;
 
@@ -46,10 +47,8 @@ Q_SIGNALS:
     void accepted();
     void rejected();
 
-protected:
-    void showMessageError(const QString& text);
-    void showMessageWarning(const QString& text);
-    void showMessageInformation(const QString& text);
+protected Q_SLOTS:
+    void showMessage(const QString& text, MessageWidget::MessageType type);
     void hideMessage();
 
 private:

--- a/src/gui/EditWidget.h
+++ b/src/gui/EditWidget.h
@@ -46,6 +46,12 @@ Q_SIGNALS:
     void accepted();
     void rejected();
 
+protected:
+    void showMessageError(const QString& text);
+    void showMessageWarning(const QString& text);
+    void showMessageInformation(const QString& text);
+    void hideMessage();
+
 private:
     const QScopedPointer<Ui::EditWidget> m_ui;
 

--- a/src/gui/EditWidget.ui
+++ b/src/gui/EditWidget.ui
@@ -12,6 +12,9 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="MessageWidget" name="messageWidget" native="true"/>
+   </item>
+   <item>
     <widget class="QLabel" name="headerLabel">
      <property name="text">
       <string/>
@@ -58,6 +61,12 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>MessageWidget</class>
+   <extends>QWidget</extends>
+   <header>gui/MessageWidget.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>CategoryListWidget</class>
    <extends>QListWidget</extends>

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -139,7 +139,7 @@ void EditWidgetIcons::addCustomIcon()
                 m_ui->customIconsView->setCurrentIndex(index);
             }
             else {
-                // TODO: show error
+                Q_EMIT messageEditEntry(tr("Error adding custom icon : ").append(filename), MessageWidget::Error);
             }
         }
     }
@@ -193,8 +193,8 @@ void EditWidgetIcons::removeCustomIcon()
                 }
             }
             else {
-                MessageBox::information(this, tr("Can't delete icon!"),
-                                        tr("Can't delete icon. Still used by %n item(s).", 0, iconUsedCount));
+                Q_EMIT messageEditEntry(tr("Can't delete icon. Still used by %n item(s).", 0, iconUsedCount)
+                                        , MessageWidget::Error);
             }
         }
     }

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -22,6 +22,7 @@
 
 #include "core/Global.h"
 #include "core/Uuid.h"
+#include "gui/MessageWidget.h"
 
 class Database;
 class DefaultIconModel;
@@ -49,6 +50,10 @@ public:
 
     IconStruct save();
     void load(Uuid currentUuid, Database* database, IconStruct iconStruct);
+
+Q_SIGNALS:
+    void messageEditEntry(QString, MessageWidget::MessageType);
+    void messageEditEntryDismiss();
 
 private Q_SLOTS:
     void addCustomIcon();

--- a/src/gui/KeePass1OpenWidget.cpp
+++ b/src/gui/KeePass1OpenWidget.cpp
@@ -64,8 +64,9 @@ void KeePass1OpenWidget::openDatabase()
         Q_EMIT editFinished(true);
     }
     else {
-        MessageBox::warning(this, tr("Error"), tr("Unable to open the database.").append("\n")
-                            .append(reader.errorString()));
+        m_ui->messageWidget->showMessage(tr("Unable to open the database.").append("\n")
+                                         .append(reader.errorString()), MessageWidget::Error);
+
         m_ui->editPassword->clear();
     }
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -42,6 +42,7 @@ MainWindow::MainWindow()
     restoreGeometry(config()->get("GUI/MainWindowGeometry").toByteArray());
 
     setWindowIcon(filePath()->applicationIcon());
+    m_ui->globalMessageWidget->setHidden(true);
     QAction* toggleViewAction = m_ui->toolBar->toggleViewAction();
     toggleViewAction->setText(tr("Show toolbar"));
     m_ui->menuView->addAction(toggleViewAction);
@@ -202,6 +203,11 @@ MainWindow::MainWindow()
 
     m_actionMultiplexer.connect(m_ui->actionSearch, SIGNAL(triggered()),
                                 SLOT(openSearch()));
+
+    connect(m_ui->tabWidget, SIGNAL(messageGlobal(QString,MessageWidget::MessageType)), this, SLOT(displayGlobalMessage(QString, MessageWidget::MessageType)));
+    connect(m_ui->tabWidget, SIGNAL(messageDismissGlobal()), this, SLOT(hideGlobalMessage()));
+    connect(m_ui->tabWidget, SIGNAL(messageTab(QString,MessageWidget::MessageType)), this, SLOT(displayTabMessage(QString, MessageWidget::MessageType)));
+    connect(m_ui->tabWidget, SIGNAL(messageDismissTab()), this, SLOT(hideTabMessage()));
 
     updateTrayIcon();
 }
@@ -582,3 +588,28 @@ bool MainWindow::isTrayIconEnabled() const
     return config()->get("GUI/ShowTrayIcon").toBool()
             && QSystemTrayIcon::isSystemTrayAvailable();
 }
+
+void MainWindow::displayGlobalMessage(const QString& text, MessageWidget::MessageType type)
+{
+    m_ui->globalMessageWidget->showMessage(text, type);
+}
+
+void MainWindow::displayTabMessage(const QString& text, MessageWidget::MessageType type)
+{
+    //if (m_ui->stackedWidget->currentIndex() == 0) {
+        m_ui->tabWidget->currentDatabaseWidget()->showMessage(text, type);
+    //}
+}
+
+void MainWindow::hideGlobalMessage()
+{
+    m_ui->globalMessageWidget->hideMessage();
+}
+
+void MainWindow::hideTabMessage()
+{
+    if (m_ui->stackedWidget->currentIndex() == 0) {
+        m_ui->tabWidget->currentDatabaseWidget()->hideMessage();
+    }
+}
+

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -65,6 +65,10 @@ private Q_SLOTS:
     void applySettingsChanges();
     void trayIconTriggered(QSystemTrayIcon::ActivationReason reason);
     void toggleWindow();
+    void displayGlobalMessage(const QString& text, MessageWidget::MessageType type);
+    void displayTabMessage(const QString& text, MessageWidget::MessageType type);
+    void hideGlobalMessage();
+    void hideTabMessage();
 
 private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>MainWindow</class>
  <widget class="QMainWindow" name="MainWindow">
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -14,12 +17,31 @@
    <string notr="true">KeePassX</string>
   </property>
   <widget class="QWidget" name="centralwidget">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
    <layout class="QVBoxLayout" name="verticalLayout">
     <property name="margin">
      <number>0</number>
     </property>
     <item>
+     <widget class="MessageWidget" name="globalMessageWidget" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+     </widget>
+    </item>
+    <item>
      <widget class="QStackedWidget" name="stackedWidget">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <property name="currentIndex">
        <number>2</number>
       </property>
@@ -70,7 +92,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>20</height>
+     <height>29</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -388,6 +410,12 @@
   </action>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>MessageWidget</class>
+   <extends>QWidget</extends>
+   <header>gui/MessageWidget.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>DatabaseTabWidget</class>
    <extends>QTabWidget</extends>

--- a/src/gui/MessageWidget.cpp
+++ b/src/gui/MessageWidget.cpp
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (C) 2015 Felix Geyer <devel@pgalves.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "MessageWidget.h"
+
+MessageWidget::MessageWidget(QWidget* parent)
+    :KMessageWidget(parent)
+{
+
+}
+
+void MessageWidget::showMessageError(const QString& text)
+{
+    showMessage(text, MessageType::Error);
+}
+
+void MessageWidget::showMessageWarning(const QString& text)
+{
+    showMessage(text, MessageType::Warning);
+}
+
+void MessageWidget::showMessagePositive(const QString& text)
+{
+    showMessage(text, MessageType::Positive);
+}
+
+void MessageWidget::showMessage(const QString& text, MessageType type)
+{
+    setMessageType(type);
+    setText(text);
+    animatedShow();
+}
+
+
+

--- a/src/gui/MessageWidget.cpp
+++ b/src/gui/MessageWidget.cpp
@@ -33,6 +33,11 @@ void MessageWidget::showMessageWarning(const QString& text)
     showMessage(text, MessageType::Warning);
 }
 
+void MessageWidget::showMessageInformation(const QString& text)
+{
+    showMessage(text, MessageType::Information);
+}
+
 void MessageWidget::showMessagePositive(const QString& text)
 {
     showMessage(text, MessageType::Positive);

--- a/src/gui/MessageWidget.cpp
+++ b/src/gui/MessageWidget.cpp
@@ -23,32 +23,14 @@ MessageWidget::MessageWidget(QWidget* parent)
 
 }
 
-void MessageWidget::showMessageError(const QString& text)
-{
-    showMessage(text, MessageType::Error);
-}
-
-void MessageWidget::showMessageWarning(const QString& text)
-{
-    showMessage(text, MessageType::Warning);
-}
-
-void MessageWidget::showMessageInformation(const QString& text)
-{
-    showMessage(text, MessageType::Information);
-}
-
-void MessageWidget::showMessagePositive(const QString& text)
-{
-    showMessage(text, MessageType::Positive);
-}
-
-void MessageWidget::showMessage(const QString& text, MessageType type)
+void MessageWidget::showMessage(const QString& text, MessageWidget::MessageType type)
 {
     setMessageType(type);
     setText(text);
     animatedShow();
 }
 
-
-
+void MessageWidget::hideMessage()
+{
+    animatedHide();
+}

--- a/src/gui/MessageWidget.cpp
+++ b/src/gui/MessageWidget.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Felix Geyer <devel@pgalves.com>
+ *  Copyright (C) 2015 Pedro Alves <devel@pgalves.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/MessageWidget.h
+++ b/src/gui/MessageWidget.h
@@ -1,0 +1,21 @@
+
+
+#ifndef MESSAGEWIDGET_H
+#define MESSAGEWIDGET_H
+
+#include "gui/kmessagewidget.h"
+
+class MessageWidget : public KMessageWidget
+{
+public:
+    explicit MessageWidget(QWidget* parent = 0);
+    void showMessageError(const QString& text);
+    void showMessageWarning(const QString& text);
+    void showMessageInformation(const QString& text);
+    void showMessagePositive(const QString& text);
+
+private:
+    void showMessage(const QString& text, MessageType type);
+};
+
+#endif // MESSAGEWIDGET_H

--- a/src/gui/MessageWidget.h
+++ b/src/gui/MessageWidget.h
@@ -1,4 +1,19 @@
-
+/*
+ *  Copyright (C) 2015 Pedro Alves <devel@pgalves.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef MESSAGEWIDGET_H
 #define MESSAGEWIDGET_H

--- a/src/gui/MessageWidget.h
+++ b/src/gui/MessageWidget.h
@@ -7,15 +7,15 @@
 
 class MessageWidget : public KMessageWidget
 {
+    Q_OBJECT
+
 public:
     explicit MessageWidget(QWidget* parent = 0);
-    void showMessageError(const QString& text);
-    void showMessageWarning(const QString& text);
-    void showMessageInformation(const QString& text);
-    void showMessagePositive(const QString& text);
 
-private:
-    void showMessage(const QString& text, MessageType type);
+public Q_SLOTS:
+    void showMessage(const QString& text, MessageWidget::MessageType type);
+    void hideMessage();
+
 };
 
 #endif // MESSAGEWIDGET_H

--- a/src/gui/UnlockDatabaseWidget.cpp
+++ b/src/gui/UnlockDatabaseWidget.cpp
@@ -46,10 +46,11 @@ void UnlockDatabaseWidget::openDatabase()
     }
 
     if (m_db->verifyKey(masterKey)) {
+        m_ui->messageWidget->setVisible(false);
         Q_EMIT editFinished(true);
     }
     else {
-        MessageBox::warning(this, tr("Error"), tr("Wrong key."));
+        m_ui->messageWidget->showMessageError(tr("Wrong key."));
         m_ui->editPassword->clear();
     }
 }

--- a/src/gui/UnlockDatabaseWidget.cpp
+++ b/src/gui/UnlockDatabaseWidget.cpp
@@ -50,7 +50,7 @@ void UnlockDatabaseWidget::openDatabase()
         Q_EMIT editFinished(true);
     }
     else {
-        m_ui->messageWidget->showMessageError(tr("Wrong key."));
+        m_ui->messageWidget->showMessage(tr("Wrong key."), MessageWidget::Error);
         m_ui->editPassword->clear();
     }
 }

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -76,6 +76,9 @@ EditEntryWidget::EditEntryWidget(QWidget* parent)
 
     connect(this, SIGNAL(accepted()), SLOT(saveEntry()));
     connect(this, SIGNAL(rejected()), SLOT(cancel()));
+
+    connect(m_iconsWidget, SIGNAL(messageEditEntry(QString, MessageWidget::MessageType)), SLOT(showMessage(QString, MessageWidget::MessageType)));
+    connect(m_iconsWidget, SIGNAL(messageEditEntryDismiss()), SLOT(hideMessage()));
 }
 
 EditEntryWidget::~EditEntryWidget()
@@ -394,7 +397,7 @@ void EditEntryWidget::saveEntry()
     }
 
     if (!passwordsEqual()) {
-        showMessageError(tr("Different passwords supplied."));
+        showMessage(tr("Different passwords supplied."), MessageWidget::Error);
         return;
     }
 
@@ -607,13 +610,13 @@ void EditEntryWidget::insertAttachment()
 
     QFile file(filename);
     if (!file.open(QIODevice::ReadOnly)) {
-        showMessageError(tr("Unable to open file").append(":\n").append(file.errorString()));
+        showMessage(tr("Unable to open file").append(":\n").append(file.errorString()), MessageWidget::Error);
         return;
     }
 
     QByteArray data;
     if (!Tools::readAllFromDevice(&file, data)) {
-        showMessageError(tr("Unable to open file").append(":\n").append(file.errorString()));
+        showMessage(tr("Unable to open file").append(":\n").append(file.errorString()), MessageWidget::Error);
         return;
     }
 
@@ -640,11 +643,11 @@ void EditEntryWidget::saveCurrentAttachment()
 
         QFile file(savePath);
         if (!file.open(QIODevice::WriteOnly)) {
-            showMessageError(tr("Unable to save the attachment:\n").append(file.errorString()));
+            showMessage(tr("Unable to save the attachment:\n").append(file.errorString()), MessageWidget::Error);
             return;
         }
         if (file.write(attachmentData) != attachmentData.size()) {
-            showMessageError(tr("Unable to save the attachment:\n").append(file.errorString()));
+            showMessage(tr("Unable to save the attachment:\n").append(file.errorString()), MessageWidget::Error);
             return;
         }
     }
@@ -665,12 +668,12 @@ void EditEntryWidget::openAttachment(const QModelIndex& index)
     QTemporaryFile* file = new QTemporaryFile(tmpFileTemplate, this);
 
     if (!file->open()) {
-        showMessageError(tr("Unable to save the attachment:\n").append(file->errorString()));
+        showMessage(tr("Unable to save the attachment:\n").append(file->errorString()), MessageWidget::Error);
         return;
     }
 
     if (file->write(attachmentData) != attachmentData.size()) {
-        showMessageError(tr("Unable to save the attachment:\n").append(file->errorString()));
+        showMessage(tr("Unable to save the attachment:\n").append(file->errorString()), MessageWidget::Error);
         return;
     }
 

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -388,12 +388,13 @@ void EditEntryWidget::saveEntry()
         m_database = Q_NULLPTR;
         m_entryAttributes->clear();
         m_entryAttachments->clear();
+        hideMessage();
         Q_EMIT editFinished(false);
         return;
     }
 
     if (!passwordsEqual()) {
-        MessageBox::warning(this, tr("Error"), tr("Different passwords supplied."));
+        showMessageError(tr("Different passwords supplied."));
         return;
     }
 
@@ -460,6 +461,7 @@ void EditEntryWidget::saveEntry()
     m_autoTypeAssoc->clear();
     m_historyModel->clear();
 
+    hideMessage();
     Q_EMIT editFinished(true);
 }
 
@@ -470,6 +472,7 @@ void EditEntryWidget::cancel()
         m_database = Q_NULLPTR;
         m_entryAttributes->clear();
         m_entryAttachments->clear();
+        hideMessage();
         Q_EMIT editFinished(false);
         return;
     }
@@ -486,6 +489,7 @@ void EditEntryWidget::cancel()
     m_autoTypeAssoc->clear();
     m_historyModel->clear();
 
+    hideMessage();
     Q_EMIT editFinished(false);
 }
 
@@ -603,15 +607,13 @@ void EditEntryWidget::insertAttachment()
 
     QFile file(filename);
     if (!file.open(QIODevice::ReadOnly)) {
-        MessageBox::warning(this, tr("Error"),
-                tr("Unable to open file").append(":\n").append(file.errorString()));
+        showMessageError(tr("Unable to open file").append(":\n").append(file.errorString()));
         return;
     }
 
     QByteArray data;
     if (!Tools::readAllFromDevice(&file, data)) {
-        MessageBox::warning(this, tr("Error"),
-                tr("Unable to open file").append(":\n").append(file.errorString()));
+        showMessageError(tr("Unable to open file").append(":\n").append(file.errorString()));
         return;
     }
 
@@ -638,13 +640,11 @@ void EditEntryWidget::saveCurrentAttachment()
 
         QFile file(savePath);
         if (!file.open(QIODevice::WriteOnly)) {
-            MessageBox::warning(this, tr("Error"),
-                    tr("Unable to save the attachment:\n").append(file.errorString()));
+            showMessageError(tr("Unable to save the attachment:\n").append(file.errorString()));
             return;
         }
         if (file.write(attachmentData) != attachmentData.size()) {
-            MessageBox::warning(this, tr("Error"),
-                    tr("Unable to save the attachment:\n").append(file.errorString()));
+            showMessageError(tr("Unable to save the attachment:\n").append(file.errorString()));
             return;
         }
     }
@@ -665,14 +665,12 @@ void EditEntryWidget::openAttachment(const QModelIndex& index)
     QTemporaryFile* file = new QTemporaryFile(tmpFileTemplate, this);
 
     if (!file->open()) {
-        MessageBox::warning(this, tr("Error"),
-                tr("Unable to save the attachment:\n").append(file->errorString()));
+        showMessageError(tr("Unable to save the attachment:\n").append(file->errorString()));
         return;
     }
 
     if (file->write(attachmentData) != attachmentData.size()) {
-        MessageBox::warning(this, tr("Error"),
-                tr("Unable to save the attachment:\n").append(file->errorString()));
+        showMessageError(tr("Unable to save the attachment:\n").append(file->errorString()));
         return;
     }
 

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -41,6 +41,9 @@ EditGroupWidget::EditGroupWidget(QWidget* parent)
 
     connect(this, SIGNAL(accepted()), SLOT(save()));
     connect(this, SIGNAL(rejected()), SLOT(cancel()));
+
+    connect(m_editGroupWidgetIcons, SIGNAL(messageEditEntry(QString, MessageWidget::MessageType)), SLOT(showMessage(QString, MessageWidget::MessageType)));
+    connect(m_editGroupWidgetIcons, SIGNAL(messageEditEntryDismiss()), SLOT(hideMessage()));
 }
 
 EditGroupWidget::~EditGroupWidget()

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -44,6 +44,8 @@ public:
 
 Q_SIGNALS:
     void editFinished(bool accepted);
+    void messageEditEntry(QString, MessageWidget::MessageType);
+    void messageEditEntryDismiss();
 
 private Q_SLOTS:
     void save();

--- a/src/gui/kmessagewidget.cpp
+++ b/src/gui/kmessagewidget.cpp
@@ -1,0 +1,425 @@
+/* This file is part of the KDE libraries
+ *
+ * Copyright (c) 2011 Aurélien Gâteau <agateau@kde.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+#include "kmessagewidget.h"
+
+#include <QEvent>
+#include <QGridLayout>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QPainter>
+#include <QShowEvent>
+#include <QTimeLine>
+#include <QToolButton>
+#include <QStyle>
+#include <QAction>
+
+void KMessageWidgetPrivate::init(KMessageWidget *q_ptr)
+{
+	q = q_ptr;
+
+	q->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+
+	timeLine = new QTimeLine(500, q);
+	QObject::connect(timeLine, SIGNAL(valueChanged(qreal)), q, SLOT(slotTimeLineChanged(qreal)));
+	QObject::connect(timeLine, SIGNAL(finished()), q, SLOT(slotTimeLineFinished()));
+
+	content = new QFrame(q);
+	content->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
+	wordWrap = false;
+
+	iconLabel = new QLabel(content);
+	iconLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+	iconLabel->hide();
+
+	textLabel = new QLabel(content);
+	textLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+	textLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
+	QObject::connect(textLabel, SIGNAL(linkActivated(const QString &)), q, SIGNAL(linkActivated(const QString &)));
+	QObject::connect(textLabel, SIGNAL(linkHovered(const QString &)), q, SIGNAL(linkHovered(const QString &)));
+
+	QAction *closeAction = new QAction(QObject::tr("Close"), q);
+	q->connect(closeAction, SIGNAL(triggered(bool)), q, SLOT(animatedHide()));
+
+	closeButton = new QToolButton(content);
+	closeButton->setAutoRaise(true);
+	closeButton->setDefaultAction(closeAction);
+    closeButton->setVisible(true);
+	q->setMessageType(KMessageWidget::Information);
+}
+
+void KMessageWidgetPrivate::createLayout()
+{
+	delete content->layout();
+
+	content->resize(q->size());
+
+	qDeleteAll(buttons);
+	buttons.clear();
+
+	Q_FOREACH (QAction *action, q->actions()) {
+		QToolButton *button = new QToolButton(content);
+		button->setDefaultAction(action);
+		button->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+		buttons.append(button);
+	}
+
+	// AutoRaise reduces visual clutter, but we don't want to turn it on if
+	// there are other buttons, otherwise the close button will look different
+	// from the others.
+	closeButton->setAutoRaise(buttons.isEmpty());
+
+	if (wordWrap) {
+		QGridLayout *layout = new QGridLayout(content);
+		// Set alignment to make sure icon does not move down if text wraps
+		layout->addWidget(iconLabel, 0, 0, 1, 1, Qt::AlignHCenter | Qt::AlignTop);
+		layout->addWidget(textLabel, 0, 1);
+
+		QDialogButtonBox *buttonLayout = new QDialogButtonBox();
+		//buttonLayout->addStretch();
+		Q_FOREACH (QToolButton *button, buttons) {
+			// For some reason, calling show() is necessary if wordwrap is true,
+			// otherwise the buttons do not show up. It is not needed if
+			// wordwrap is false.
+			button->show();
+			buttonLayout->addButton(button, QDialogButtonBox::QDialogButtonBox::AcceptRole);
+		}
+		buttonLayout->addButton(closeButton, QDialogButtonBox::RejectRole);
+		layout->addWidget(buttonLayout, 1, 0, 1, 2, Qt::AlignHCenter | Qt::AlignTop);
+	} else {
+		bool closeButtonVisible = closeButton->isVisible();
+		QHBoxLayout *layout = new QHBoxLayout(content);
+		layout->addWidget(iconLabel);
+		layout->addWidget(textLabel);
+
+		QDialogButtonBox *buttonLayout = new QDialogButtonBox();
+		Q_FOREACH (QToolButton *button, buttons) {
+			buttonLayout->addButton(button, QDialogButtonBox::QDialogButtonBox::AcceptRole);
+		}
+
+		buttonLayout->addButton(closeButton, QDialogButtonBox::RejectRole);
+		// Something gets changed when added to the buttonLayout
+        closeButton->setVisible(closeButtonVisible);
+		layout->addWidget(buttonLayout);
+	};
+
+	if (q->isVisible()) {
+		q->setFixedHeight(content->sizeHint().height());
+	}
+
+	q->updateGeometry();
+}
+
+void KMessageWidgetPrivate::updateLayout()
+{
+	if (content->layout()) {
+		createLayout();
+	}
+}
+
+void KMessageWidgetPrivate::updateSnapShot()
+{
+	// Attention: updateSnapShot calls QWidget::render(), which causes the whole
+	// window layouts to be activated. Calling this method from resizeEvent()
+	// can lead to infinite recursion, see:
+	// https://bugs.kde.org/show_bug.cgi?id=311336
+	contentSnapShot = QPixmap(content->size());
+	contentSnapShot.fill(Qt::transparent);
+	content->render(&contentSnapShot, QPoint(), QRegion(), QWidget::DrawChildren);
+}
+
+void KMessageWidgetPrivate::slotTimeLineChanged(qreal value)
+{
+	q->setFixedHeight(qMin(value * 2, qreal(1.0)) * content->height());
+	q->update();
+}
+
+void KMessageWidgetPrivate::slotTimeLineFinished()
+{
+	if (timeLine->direction() == QTimeLine::Forward) {
+		// Show
+		// We set the whole geometry here, because it may be wrong if a
+		// KMessageWidget is shown right when the toplevel window is created.
+		content->setGeometry(0, 0, q->width(), bestContentHeight());
+	} else {
+		// Hide
+		q->hide();
+	}
+}
+
+int KMessageWidgetPrivate::bestContentHeight() const
+{
+	int height = content->heightForWidth(q->width());
+
+	if (height == -1) {
+		height = content->sizeHint().height();
+	}
+
+	return height;
+}
+
+
+//---------------------------------------------------------------------
+// KMessageWidget
+//---------------------------------------------------------------------
+KMessageWidget::KMessageWidget(QWidget *parent) : QFrame(parent), d(new KMessageWidgetPrivate)
+{
+	d->init(this);
+}
+
+KMessageWidget::KMessageWidget(const QString &text, QWidget *parent) : QFrame(parent), d(new KMessageWidgetPrivate)
+{
+	d->init(this);
+	setText(text);
+}
+
+KMessageWidget::~KMessageWidget()
+{
+	delete d;
+}
+
+QString KMessageWidget::text() const
+{
+	return d->textLabel->text();
+}
+
+void KMessageWidget::setText(const QString &text)
+{
+	d->textLabel->setText(text);
+	updateGeometry();
+}
+
+int KMessageWidget::bestContentHeight() const
+{
+	return d->bestContentHeight();
+}
+
+
+KMessageWidget::MessageType KMessageWidget::messageType() const
+{
+	return d->messageType;
+}
+
+void KMessageWidget::setMessageType(KMessageWidget::MessageType type)
+{
+	d->messageType = type;
+	QColor bg0, bg1, bg2, border, fg;
+
+	switch (type) {
+	case Positive:
+		bg1 = QColor("#72D594"); // nice green
+		fg = QColor(Qt::white);
+		break;
+
+	case Information:
+		bg1 = QColor("#41A8E3"); // nice blue
+		fg = QColor(Qt::black);
+		break;
+
+	case Warning:
+        bg1 = QColor("#FFCD0F"); // nice yellow
+		fg = QColor(Qt::black);
+		break;
+
+	case Error:
+        bg1 = QColor("#FF7D7D"); // nice red.
+		fg = QColor(Qt::black);
+		break;
+	}
+
+	// Colors
+	bg0 = bg1.lighter(110);
+	bg2 = bg1.darker(110);
+	border = bg2.darker(110);
+	d->content->setStyleSheet(
+		QString(".QFrame {"
+			"background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,"
+			"    stop: 0 %1,"
+			"    stop: 0.1 %2,"
+			"    stop: 1.0 %3);"
+			"border-radius: 5px;"
+			"border: 1px solid %4;"
+			"margin: %5px;"
+			"}"
+			".QLabel { color: %6; }").arg(bg0.name())
+			.arg(bg1.name())
+			.arg(bg2.name())
+			.arg(border.name())
+		/*
+		DefaultFrameWidth returns the size of the external margin + border width.
+		We know our border is 1px, so we subtract this from the frame
+		normal QStyle FrameWidth to get our margin
+		*/
+			.arg(style()->pixelMetric(QStyle::PM_DefaultFrameWidth, 0, this) - 1)
+			.arg(fg.name()));
+}
+
+QSize KMessageWidget::sizeHint() const
+{
+	ensurePolished();
+	return d->content->sizeHint();
+}
+
+QSize KMessageWidget::minimumSizeHint() const
+{
+	ensurePolished();
+	return d->content->minimumSizeHint();
+}
+
+bool KMessageWidget::event(QEvent *event)
+{
+	if (event->type() == QEvent::Polish && !d->content->layout()) {
+		d->createLayout();
+	}
+
+	return QFrame::event(event);
+}
+
+void KMessageWidget::resizeEvent(QResizeEvent *event)
+{
+	QFrame::resizeEvent(event);
+
+	if (d->timeLine->state() == QTimeLine::NotRunning) {
+		d->content->resize(width(), d->bestContentHeight());
+	}
+}
+
+int KMessageWidget::heightForWidth(int width) const
+{
+	ensurePolished();
+	return d->content->heightForWidth(width);
+}
+
+void KMessageWidget::paintEvent(QPaintEvent *event)
+{
+	QFrame::paintEvent(event);
+
+	if (d->timeLine->state() == QTimeLine::Running) {
+		QPainter painter(this);
+		painter.setOpacity(d->timeLine->currentValue() * d->timeLine->currentValue());
+		painter.drawPixmap(0, 0, d->contentSnapShot);
+	}
+}
+
+void KMessageWidget::showEvent(QShowEvent *event)
+{
+	// Keep this method here to avoid breaking binary compatibility:
+	// QFrame::showEvent() used to be reimplemented.
+	QFrame::showEvent(event);
+}
+
+bool KMessageWidget::wordWrap() const
+{
+	return d->wordWrap;
+}
+
+void KMessageWidget::setWordWrap(bool wordWrap)
+{
+	d->wordWrap = wordWrap;
+	d->textLabel->setWordWrap(wordWrap);
+	QSizePolicy policy = sizePolicy();
+	policy.setHeightForWidth(wordWrap);
+	setSizePolicy(policy);
+	d->updateLayout();
+
+	// Without this, when user does wordWrap -> !wordWrap -> wordWrap, a minimum
+	// height is set, causing the widget to be too high.
+	// Mostly visible in test programs.
+	if (wordWrap) {
+		setMinimumHeight(0);
+	}
+}
+
+bool KMessageWidget::isCloseButtonVisible() const
+{
+	return d->closeButton->isVisible();
+}
+
+void KMessageWidget::setCloseButtonVisible(bool show)
+{
+	d->closeButton->setVisible(show);
+	updateGeometry();
+}
+
+void KMessageWidget::addAction(QAction *action)
+{
+	QFrame::addAction(action);
+	d->updateLayout();
+}
+
+void KMessageWidget::removeAction(QAction *action)
+{
+	QFrame::removeAction(action);
+	d->updateLayout();
+}
+
+void KMessageWidget::animatedShow()
+{
+	if (isVisible()) {
+		return;
+	}
+
+	QFrame::show();
+	setFixedHeight(0);
+	int wantedHeight = d->bestContentHeight();
+	d->content->setGeometry(0, -wantedHeight, width(), wantedHeight);
+
+	d->updateSnapShot();
+
+	d->timeLine->setDirection(QTimeLine::Forward);
+
+	if (d->timeLine->state() == QTimeLine::NotRunning) {
+		d->timeLine->start();
+	}
+}
+
+void KMessageWidget::animatedHide()
+{
+	if (!isVisible()) {
+		hide();
+		return;
+	}
+
+	d->content->move(0, -d->content->height());
+	d->updateSnapShot();
+
+	d->timeLine->setDirection(QTimeLine::Backward);
+
+	if (d->timeLine->state() == QTimeLine::NotRunning) {
+		d->timeLine->start();
+	}
+}
+
+QIcon KMessageWidget::icon() const
+{
+	return d->icon;
+}
+
+void KMessageWidget::setIcon(const QIcon &icon)
+{
+	d->icon = icon;
+
+	if (d->icon.isNull()) {
+		d->iconLabel->hide();
+	} else {
+		d->iconLabel->setPixmap(d->icon.pixmap(QSize(16, 16)));
+		d->iconLabel->show();
+	}
+}

--- a/src/gui/kmessagewidget.h
+++ b/src/gui/kmessagewidget.h
@@ -1,0 +1,239 @@
+/* This file is part of the KDE libraries
+ *
+ * Copyright (c) 2011 Aurélien Gâteau <agateau@kde.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+#ifndef KMESSAGEWIDGET_H
+#define KMESSAGEWIDGET_H
+
+#include <QFrame>
+
+class KMessageWidgetPrivate;
+
+/**
+ * @short A widget to provide feedback or propose opportunistic interactions.
+ *
+ * KMessageWidget can be used to provide inline positive or negative
+ * feedback, or to implement opportunistic interactions.
+ *
+ * As a feedback widget, KMessageWidget provides a less intrusive alternative
+ * to "OK Only" message boxes. If you do not need the modalness of KMessageBox,
+ * consider using KMessageWidget instead.
+ *
+ * <b>Negative feedback</b>
+ *
+ * The KMessageWidget can be used as a secondary indicator of failure: the
+ * first indicator is usually the fact the action the user expected to happen
+ * did not happen.
+ *
+ * Example: User fills a form, clicks "Submit".
+ *
+ * @li Expected feedback: form closes
+ * @li First indicator of failure: form stays there
+ * @li Second indicator of failure: a KMessageWidget appears on top of the
+ * form, explaining the error condition
+ *
+ * When used to provide negative feedback, KMessageWidget should be placed
+ * close to its context. In the case of a form, it should appear on top of the
+ * form entries.
+ *
+ * KMessageWidget should get inserted in the existing layout. Space should not
+ * be reserved for it, otherwise it becomes "dead space", ignored by the user.
+ * KMessageWidget should also not appear as an overlay to prevent blocking
+ * access to elements the user needs to interact with to fix the failure.
+ *
+ * <b>Positive feedback</b>
+ *
+ * KMessageWidget can be used for positive feedback but it shouldn't be
+ * overused. It is often enough to provide feedback by simply showing the
+ * results of an action.
+ *
+ * Examples of acceptable uses:
+ *
+ * @li Confirm success of "critical" transactions
+ * @li Indicate completion of background tasks
+ *
+ * Example of inadapted uses:
+ *
+ * @li Indicate successful saving of a file
+ * @li Indicate a file has been successfully removed
+ *
+ * <b>Opportunistic interaction</b>
+ *
+ * Opportunistic interaction is the situation where the application suggests to
+ * the user an action he could be interested in perform, either based on an
+ * action the user just triggered or an event which the application noticed.
+ *
+ * Example of acceptable uses:
+ *
+ * @li A browser can propose remembering a recently entered password
+ * @li A music collection can propose ripping a CD which just got inserted
+ * @li A chat application may notify the user a "special friend" just connected
+ *
+ * @author Aurélien Gâteau <agateau@kde.org>
+ * @since 4.7
+ */
+class KMessageWidget : public QFrame {
+	Q_OBJECT
+	Q_ENUMS(MessageType)
+
+	Q_PROPERTY(QString text READ text WRITE setText)
+	Q_PROPERTY(bool wordWrap READ wordWrap WRITE setWordWrap)
+	Q_PROPERTY(bool closeButtonVisible READ isCloseButtonVisible WRITE setCloseButtonVisible)
+	Q_PROPERTY(MessageType messageType READ messageType WRITE setMessageType)
+	Q_PROPERTY(QIcon icon READ icon WRITE setIcon)
+public:
+	enum MessageType {
+		Positive,
+		Information,
+		Warning,
+		Error
+	};
+
+	/**
+	 * Constructs a KMessageWidget with the specified parent.
+	 */
+	explicit KMessageWidget(QWidget *parent = 0);
+
+	explicit KMessageWidget(const QString &text, QWidget *parent = 0);
+
+	~KMessageWidget();
+
+	QString text() const;
+
+	bool wordWrap() const;
+
+	bool isCloseButtonVisible() const;
+
+	MessageType messageType() const;
+
+	void addAction(QAction *action);
+
+	void removeAction(QAction *action);
+
+	QSize sizeHint() const;
+
+	QSize minimumSizeHint() const;
+
+	int heightForWidth(int width) const;
+
+	/**
+	 * The icon shown on the left of the text. By default, no icon is shown.
+	 * @since 4.11
+	 */
+	QIcon icon() const;
+
+public
+Q_SLOTS:
+	void setText(const QString &text);
+
+	void setWordWrap(bool wordWrap);
+
+	void setCloseButtonVisible(bool visible);
+
+	void setMessageType(KMessageWidget::MessageType type);
+
+	/**
+	 * Show the widget using an animation, unless
+	 * KGlobalSettings::graphicsEffectLevel() does not allow simple effects.
+	 */
+	void animatedShow();
+
+	/**
+	 * Hide the widget using an animation, unless
+	 * KGlobalSettings::graphicsEffectLevel() does not allow simple effects.
+	 */
+	void animatedHide();
+
+	/**
+	 * Define an icon to be shown on the left of the text
+	 * @since 4.11
+	 */
+	void setIcon(const QIcon &icon);
+
+	int bestContentHeight() const;
+Q_SIGNALS:
+	/**
+	 * This signal is emitted when the user clicks a link in the text label.
+	 * The URL referred to by the href anchor is passed in contents.
+	 * @param contents text of the href anchor
+	 * @see QLabel::linkActivated()
+	 * @since 4.10
+	 */
+	void linkActivated(const QString &contents);
+
+	/**
+	 * This signal is emitted when the user hovers over a link in the text label.
+	 * The URL referred to by the href anchor is passed in contents.
+	 * @param contents text of the href anchor
+	 * @see QLabel::linkHovered()
+	 * @since 4.11
+	 */
+	void linkHovered(const QString &contents);
+
+protected:
+	void paintEvent(QPaintEvent *event);
+
+	bool event(QEvent *event);
+
+	void resizeEvent(QResizeEvent *event);
+
+	void showEvent(QShowEvent *event);
+
+private:
+	KMessageWidgetPrivate *const d;
+	friend class KMessageWidgetPrivate;
+
+	Q_PRIVATE_SLOT(d, void slotTimeLineChanged(qreal))
+	Q_PRIVATE_SLOT(d, void slotTimeLineFinished())
+};
+
+//---------------------------------------------------------------------
+// KMessageWidgetPrivate
+//---------------------------------------------------------------------
+class QLabel;
+class QToolButton;
+class QTimeLine;
+#include <QIcon>
+
+class KMessageWidgetPrivate {
+public:
+	void init(KMessageWidget *);
+
+	KMessageWidget *q;
+	QFrame *content;
+	QLabel *iconLabel;
+	QLabel *textLabel;
+	QToolButton *closeButton;
+	QTimeLine *timeLine;
+	QIcon icon;
+
+	KMessageWidget::MessageType messageType;
+	bool wordWrap;
+	QList<QToolButton *> buttons;
+	QPixmap contentSnapShot;
+
+	void createLayout();
+	void updateSnapShot();
+	void updateLayout();
+	void slotTimeLineChanged(qreal);
+	void slotTimeLineFinished();
+
+	int bestContentHeight() const;
+};
+
+#endif // KMESSAGEWIDGET_H


### PR DESCRIPTION
This pull request replaces the message dialogs not requiring user interaction (passive information) with an inline message widget. The code used for the widget is borrowed from [subsurface](https://github.com/torvalds/subsurface/blob/master/qt-ui/kmessagewidget.cpp). This widget is similar to KMessageWidget from KDE libraries but has the KDE bits removed. 

Messages can be displayed over the Tab Bar for generic messages or inside the tab for messages related with tab content.

Only tested on Linux.

Some screenshots:
![wrong_key](https://cloud.githubusercontent.com/assets/311987/5840934/efd29f62-a190-11e4-8381-fe3b7152bb5b.png)
![read_only_mode](https://cloud.githubusercontent.com/assets/311987/5840937/f9b18746-a190-11e4-8967-90eb36b9c8d5.png)
![open_file_no_permission](https://cloud.githubusercontent.com/assets/311987/5840939/fc382e8e-a190-11e4-95aa-4e462d49586c.png)
![nomatch_passwords](https://cloud.githubusercontent.com/assets/311987/5840940/fe053810-a190-11e4-8d5b-f2d3c5ebd598.png)
![delete_used_custom_icon](https://cloud.githubusercontent.com/assets/311987/5840941/00c33e26-a191-11e4-8bc6-2df1a081b779.png)

