### PR TITLE
Issue #270 - turning off key location memory

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -89,6 +89,7 @@ void Config::init(const QString& fileName)
     m_settings.reset(new QSettings(fileName, QSettings::IniFormat));
 
     m_defaults.insert("RememberLastDatabases", true);
+    m_defaults.insert("RememberLastKeyFiles", true);
     m_defaults.insert("OpenPreviousDatabasesOnStartup", true);
     m_defaults.insert("AutoSaveAfterEveryChange", false);
     m_defaults.insert("AutoSaveOnExit", false);

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -67,10 +67,12 @@ void DatabaseOpenWidget::load(const QString& filename)
 
     m_ui->labelFilename->setText(filename);
 
-    QHash<QString, QVariant> lastKeyFiles = config()->get("LastKeyFiles").toHash();
-    if (lastKeyFiles.contains(m_filename)) {
-        m_ui->checkKeyFile->setChecked(true);
-        m_ui->comboKeyFile->addItem(lastKeyFiles[m_filename].toString());
+    if(config()->get("RememberLastKeyFiles").toBool()) {
+        QHash<QString, QVariant> lastKeyFiles = config()->get("LastKeyFiles").toHash();
+        if (lastKeyFiles.contains(m_filename)) {
+            m_ui->checkKeyFile->setChecked(true);
+            m_ui->comboKeyFile->addItem(lastKeyFiles[m_filename].toString());
+        }
     }
 
     m_ui->editPassword->setFocus();
@@ -148,7 +150,9 @@ CompositeKey DatabaseOpenWidget::databaseKey()
         lastKeyFiles.remove(m_filename);
     }
 
-    config()->set("LastKeyFiles", lastKeyFiles);
+    if(config()->get("RememberLastKeyFiles").toBool()) {
+        config()->set("LastKeyFiles", lastKeyFiles);
+    }
 
     return masterKey;
 }

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -63,6 +63,7 @@ SettingsWidget::~SettingsWidget()
 void SettingsWidget::loadSettings()
 {
     m_generalUi->rememberLastDatabasesCheckBox->setChecked(config()->get("RememberLastDatabases").toBool());
+    m_generalUi->rememberLastKeyFilesCheckBox->setChecked(config()->get("RememberLastKeyFiles").toBool());
     m_generalUi->openPreviousDatabasesOnStartupCheckBox->setChecked(
         config()->get("OpenPreviousDatabasesOnStartup").toBool());
     m_generalUi->autoSaveAfterEveryChangeCheckBox->setChecked(config()->get("AutoSaveAfterEveryChange").toBool());
@@ -108,6 +109,7 @@ void SettingsWidget::loadSettings()
 void SettingsWidget::saveSettings()
 {
     config()->set("RememberLastDatabases", m_generalUi->rememberLastDatabasesCheckBox->isChecked());
+    config()->set("RememberLastKeyFiles", m_generalUi->rememberLastKeyFilesCheckBox->isChecked());
     config()->set("OpenPreviousDatabasesOnStartup",
                   m_generalUi->openPreviousDatabasesOnStartupCheckBox->isChecked());
     config()->set("AutoSaveAfterEveryChange",

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -25,75 +25,85 @@
     </widget>
    </item>
    <item row="1" column="0">
+    <widget class="QCheckBox" name="rememberLastKeyFilesCheckBox">
+     <property name="text">
+      <string>Remember last key files</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
     <widget class="QCheckBox" name="openPreviousDatabasesOnStartupCheckBox">
      <property name="text">
       <string>Open previous databases on startup</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QCheckBox" name="autoSaveOnExitCheckBox">
      <property name="text">
       <string>Automatically save on exit</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QCheckBox" name="autoSaveAfterEveryChangeCheckBox">
      <property name="text">
       <string>Automatically save after every change</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QCheckBox" name="minimizeOnCopyCheckBox">
      <property name="text">
       <string>Minimize when copying to clipboard</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QCheckBox" name="useGroupIconOnEntryCreationCheckBox">
      <property name="text">
       <string>Use group icon on entry creation</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="autoTypeShortcutLabel">
      <property name="text">
       <string>Global Auto-Type shortcut</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="7" column="1">
     <widget class="ShortcutWidget" name="autoTypeShortcutWidget"/>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <widget class="QCheckBox" name="autoTypeEntryTitleMatchCheckBox">
      <property name="text">
       <string>Use entry title to match windows for global auto-type</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="languageLabel">
      <property name="text">
       <string>Language</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="9" column="1">
     <widget class="QComboBox" name="languageComboBox"/>
    </item>
-   <item row="9" column="0">
+   <item row="10" column="0">
     <widget class="QCheckBox" name="systrayShowCheckBox">
      <property name="text">
       <string>Show a system tray icon</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="0">
+   <item row="11" column="0">
     <widget class="QCheckBox" name="systrayMinimizeToTrayCheckBox">
      <property name="enabled">
       <bool>false</bool>
@@ -114,6 +124,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>rememberLastDatabasesCheckBox</tabstop>
+  <tabstop>rememberLastKeyFilesCheckBox</tabstop>
   <tabstop>openPreviousDatabasesOnStartupCheckBox</tabstop>
   <tabstop>autoSaveOnExitCheckBox</tabstop>
   <tabstop>autoSaveAfterEveryChangeCheckBox</tabstop>


### PR DESCRIPTION
Add general settting for whether or not to remember last key files
Note: disabling this new setting does not remove entries from config file.  To remove the persisted key file associated with a database filename, attempt to open the database with only a password (no key file) with "Remember last key files" enabled.  That removes the key file entry for that database filename.  Next, change the "Remember last key files" setting to disabled to prevent it from persisting any further mapping.

If you want to remove the mappings for all database files, you can repeat the above procedure for each database file.  Or alternatively, you could remove the "LastKeyFiles=" line from the config file (~/.config/keepassx/keepassx2.ini" in my case).