### PR TITLE
For Bug #274

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 CMakeLists.txt.*
 build/
+.project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# Look for MacPorts installed libraries ahead of native Mac libraries
+list(APPEND CMAKE_LIBRARY_PATH /opt/local/lib) 
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
       "Choose the type of build, options are: None Debug Release RelWithDebInfo Debug Debugfull Profile MinSizeRel."

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -358,6 +358,8 @@ void DatabaseWidget::copyTitle()
 
 void DatabaseWidget::copyUsername()
 {
+	//Hack for workaround of ticket #274 until I find a better solution
+	m_entryView->setFocus();
     Entry* currentEntry = m_entryView->currentEntry();
     if (!currentEntry) {
         Q_ASSERT(false);
@@ -368,13 +370,12 @@ void DatabaseWidget::copyUsername()
 }
 
 void DatabaseWidget::copyPassword()
-{
+{	
     Entry* currentEntry = m_entryView->currentEntry();
     if (!currentEntry) {
         Q_ASSERT(false);
         return;
     }
-
     setClipboardTextAndMinimize(currentEntry->password());
 }
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -358,8 +358,9 @@ void DatabaseWidget::copyTitle()
 
 void DatabaseWidget::copyUsername()
 {
-	//Hack for workaround of ticket #274 until I find a better solution
-	m_entryView->setFocus();
+	if(!m_entryView->hasFocus()){
+		m_entryView->setFocus();	
+	}
     Entry* currentEntry = m_entryView->currentEntry();
     if (!currentEntry) {
         Q_ASSERT(false);
@@ -381,6 +382,9 @@ void DatabaseWidget::copyPassword()
 
 void DatabaseWidget::copyURL()
 {
+	if(!m_entryView->hasFocus()){
+		m_entryView->setFocus();	
+	}
     Entry* currentEntry = m_entryView->currentEntry();
     if (!currentEntry) {
         Q_ASSERT(false);
@@ -433,6 +437,9 @@ void DatabaseWidget::performAutoType()
 
 void DatabaseWidget::openUrl()
 {
+	if(!m_entryView->hasFocus()){
+		m_entryView->setFocus();	
+	}
     Entry* currentEntry = m_entryView->currentEntry();
     if (!currentEntry) {
         Q_ASSERT(false);


### PR DESCRIPTION
This PR covers all changes I had to make to implement a fix for Bug #274.  With this patch, focus is moved to the selected Entry if copyUsername, copyURL, or openURL are triggered.