### PR TITLE
Patch for Bug 274 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# Look for MacPorts installed libraries ahead of native Mac libraries
+list(APPEND CMAKE_LIBRARY_PATH /opt/local/lib) 
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
       "Choose the type of build, options are: None Debug Release RelWithDebInfo Debug Debugfull Profile MinSizeRel."

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -156,6 +156,7 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     connect(m_unlockDatabaseWidget, SIGNAL(editFinished(bool)), SLOT(unlockDatabase(bool)));
     connect(this, SIGNAL(currentChanged(int)), this, SLOT(emitCurrentModeChanged()));
     connect(m_searchUi->searchEdit, SIGNAL(textChanged(QString)), this, SLOT(startSearchTimer()));
+    connect(m_searchUi->searchEdit, SIGNAL(copyPasswordActivated()), this, SLOT(copyPassword()));
     connect(m_searchUi->caseSensitiveCheckBox, SIGNAL(toggled(bool)), this, SLOT(startSearch()));
     connect(m_searchUi->searchCurrentRadioButton, SIGNAL(toggled(bool)), this, SLOT(startSearch()));
     connect(m_searchUi->searchRootRadioButton, SIGNAL(toggled(bool)), this, SLOT(startSearch()));

--- a/src/gui/LineEdit.cpp
+++ b/src/gui/LineEdit.cpp
@@ -55,6 +55,14 @@ LineEdit::LineEdit(QWidget* parent)
                    qMax(msz.height(), m_clearButton->sizeHint().height() + frameWidth * 2 + 2));
 }
 
+void LineEdit::keyPressEvent(QKeyEvent *event)
+{
+    if( (event->key() == Qt::Key_C) && (event->modifiers() & Qt::ControlModifier) ){
+		Q_EMIT copyPasswordActivated();
+    }    
+    QLineEdit::keyPressEvent(event);    
+}
+
 void LineEdit::resizeEvent(QResizeEvent* event)
 {
     QSize sz = m_clearButton->sizeHint();

--- a/src/gui/LineEdit.h
+++ b/src/gui/LineEdit.h
@@ -21,6 +21,8 @@
 #define KEEPASSX_LINEEDIT_H
 
 #include <QLineEdit>
+#include <QMessageBox>
+#include <QKeyEvent>
 
 #include "core/Global.h"
 
@@ -33,8 +35,13 @@ class LineEdit : public QLineEdit
 public:
     explicit LineEdit(QWidget* parent = Q_NULLPTR);
 
+Q_SIGNALS:
+    void copyPasswordActivated();
+
+
 protected:
     void resizeEvent(QResizeEvent* event) Q_DECL_OVERRIDE;
+    void keyPressEvent(QKeyEvent* event) Q_DECL_OVERRIDE;
 
 private Q_SLOTS:
     void updateCloseButton(const QString& text);


### PR DESCRIPTION
This is a better (second) attempt at addressing the bug I opened (#274). Here I have the search LineEdit emit a signal to invoke copy password upon a Command+C keystroke if and only if no text is currently selected (the LineEdit never receives the key event in that case). No change to focus is required.

The end result is that Command+C can be used to copy the current entry's password without altering the expected behavior of Command+C (it will default to copying any selected text).


