### PR TITLE
Set default save extension (Fixes #79)

### DIFF
--- a/src/gui/FileDialog.cpp
+++ b/src/gui/FileDialog.cpp
@@ -65,8 +65,23 @@ QString FileDialog::getSaveFileName(QWidget* parent, const QString& caption, QSt
             dir = config()->get("LastDir").toString();
         }
 
-        QString result = QFileDialog::getSaveFileName(parent, caption, dir, filter,
-                                                      selectedFilter, options);
+        QFileDialog dialog(parent, caption, dir, filter);
+        dialog.setAcceptMode(QFileDialog::AcceptSave);
+        dialog.setFileMode(QFileDialog::AnyFile);
+        if (selectedFilter) {
+            dialog.selectNameFilter(*selectedFilter);
+        }
+        dialog.setOptions(options);
+        dialog.setDefaultSuffix("kdbx");
+
+        QString result;
+        QStringList results;
+        if (dialog.exec()) {
+            results = dialog.selectedFiles();
+            if (!results.isEmpty()) {
+                result = results[0];
+            }
+        }
 
         // on Mac OS X the focus is lost after closing the native dialog
         if (parent) {


### PR DESCRIPTION
In QFileDialog, setDefaultSuffix allows to specify the default file extension when no extension is specified. However, it cannot be done using the static function. You need to explicitly create a QFileDialog object to be able to set this property.