### PR TITLE
Add keyboard shortcut (Ctrl-Alt-U) for copy URL to clipboard.

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -90,6 +90,7 @@ MainWindow::MainWindow()
     m_ui->actionEntryCopyPassword->setShortcut(Qt::CTRL + Qt::Key_C);
     setShortcut(m_ui->actionEntryAutoType, QKeySequence::Paste, Qt::CTRL + Qt::Key_V);
     m_ui->actionEntryOpenUrl->setShortcut(Qt::CTRL + Qt::Key_U);
+    m_ui->actionEntryCopyURL->setShortcut(Qt::CTRL + Qt::ALT + Qt::Key_U);
 
 #ifdef Q_OS_MAC
     new QShortcut(Qt::CTRL + Qt::Key_M, this, SLOT(showMinimized()));


### PR DESCRIPTION
Sometimes, I really don't want to open a URL in my default browser, or I want to open it in a private session, or in Tor or something. Having to right-click to copy the URL to the clipboard was super annoying.

Simple fix to add a shortcut (Ctrl-Alt-U) to copy URL to clipboard. This turns out to be Command-Option-U (⌥⌘-U) on Mac. I couldn't find any conflicts in code or the OS. I have not tested on Windows.

The context menu on Mac looks good:

![image](https://cloud.githubusercontent.com/assets/716733/8142701/f4cbb69c-113a-11e5-93a3-846e0c5775ba.png)
