### PR TITLE
Bug #352 Icon in About dialog clipped

### DIFF
--- a/src/gui/AboutDialog.ui
+++ b/src/gui/AboutDialog.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>AboutDialog</class>
  <widget class="QDialog" name="AboutDialog">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>366</width>
-    <height>210</height>
-   </rect>
-  </property>
   <property name="windowTitle">
    <string>About KeePassX</string>
   </property>


### PR DESCRIPTION
Removed explicitly set "geometry" property from About Dialog.

Fix for https://www.keepassx.org/dev/issues/352