### PR TITLE
Fixes #347 - Support multiple auto-type matches per entry

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(keepassx_SOURCES
     autotype/WindowSelectComboBox.cpp
     autotype/test/AutoTypeTestInterface.h
     core/AutoTypeAssociations.cpp
+    core/AutoTypeMatch.cpp
     core/Config.cpp
     core/Database.cpp
     core/DatabaseIcons.cpp
@@ -109,6 +110,8 @@ set(keepassx_SOURCES
     gui/UnlockDatabaseWidget.cpp
     gui/WelcomeWidget.cpp
     gui/entry/AutoTypeAssociationsModel.cpp
+    gui/entry/AutoTypeMatchModel.cpp
+    gui/entry/AutoTypeMatchView.cpp
     gui/entry/EditEntryWidget.cpp
     gui/entry/EditEntryWidget_p.h
     gui/entry/EntryAttachmentsModel.cpp
@@ -166,6 +169,7 @@ set(keepassx_MOC
     autotype/ShortcutWidget.h
     autotype/WindowSelectComboBox.h
     core/AutoTypeAssociations.h
+    core/AutoTypeMatch.h
     core/Config.h
     core/Database.h
     core/Entry.h
@@ -201,6 +205,8 @@ set(keepassx_MOC
     gui/UnlockDatabaseWidget.h
     gui/WelcomeWidget.h
     gui/entry/AutoTypeAssociationsModel.h
+    gui/entry/AutoTypeMatchModel.h
+    gui/entry/AutoTypeMatchView.h
     gui/entry/EditEntryWidget.h
     gui/entry/EntryAttachmentsModel.h
     gui/entry/EntryAttributesModel.h

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -23,6 +23,7 @@
 #include <QWidget>
 
 #include "core/Global.h"
+#include "core/AutoTypeMatch.h"
 
 class AutoTypeAction;
 class AutoTypeExecutor;
@@ -57,7 +58,7 @@ Q_SIGNALS:
     void globalShortcutTriggered();
 
 private Q_SLOTS:
-    void performAutoTypeFromGlobal(Entry* entry, const QString& sequence);
+    void performAutoTypeFromGlobal(AutoTypeMatch match);
     void resetInAutoType();
     void unloadPlugin();
 
@@ -67,7 +68,8 @@ private:
     void loadPlugin(const QString& pluginPath);
     bool parseActions(const QString& sequence, const Entry* entry, QList<AutoTypeAction*>& actions);
     QList<AutoTypeAction*> createActionFromTemplate(const QString& tmpl, const Entry* entry);
-    QString autoTypeSequence(const Entry* entry, const QString& windowTitle = QString());
+    QString findDefaultAutoTypeSequence(const Entry* entry);
+    QList<QString> autoTypeSequences(const Entry* entry, const QString& windowTitle = QString());
     bool windowMatches(const QString& windowTitle, const QString& windowPattern);
 
     bool m_inAutoType;

--- a/src/autotype/AutoTypeSelectView.cpp
+++ b/src/autotype/AutoTypeSelectView.cpp
@@ -20,15 +20,12 @@
 #include <QMouseEvent>
 
 AutoTypeSelectView::AutoTypeSelectView(QWidget* parent)
-    : EntryView(parent)
+    : AutoTypeMatchView(parent)
 {
-    hideColumn(3);
     setMouseTracking(true);
     setAllColumnsShowFocus(true);
-    setDragEnabled(false);
-    setSelectionMode(QAbstractItemView::SingleSelection);
 
-    connect(model(), SIGNAL(modelReset()), SLOT(selectFirstEntry()));
+    connect(model(), SIGNAL(modelReset()), SLOT(selectFirstMatch()));
 }
 
 void AutoTypeSelectView::mouseMoveEvent(QMouseEvent* event)
@@ -43,10 +40,10 @@ void AutoTypeSelectView::mouseMoveEvent(QMouseEvent* event)
         unsetCursor();
     }
 
-    EntryView::mouseMoveEvent(event);
+    AutoTypeMatchView::mouseMoveEvent(event);
 }
 
-void AutoTypeSelectView::selectFirstEntry()
+void AutoTypeSelectView::selectFirstMatch()
 {
     QModelIndex index = model()->index(0, 0);
 

--- a/src/autotype/AutoTypeSelectView.h
+++ b/src/autotype/AutoTypeSelectView.h
@@ -19,11 +19,10 @@
 #define KEEPASSX_AUTOTYPESELECTVIEW_H
 
 #include "core/Global.h"
-#include "gui/entry/EntryView.h"
+#include "core/AutoTypeMatch.h"
+#include "gui/entry/AutoTypeMatchView.h"
 
-class Entry;
-
-class AutoTypeSelectView : public EntryView
+class AutoTypeSelectView : public AutoTypeMatchView
 {
     Q_OBJECT
 
@@ -34,7 +33,7 @@ protected:
     void mouseMoveEvent(QMouseEvent* event) Q_DECL_OVERRIDE;
 
 private Q_SLOTS:
-    void selectFirstEntry();
+    void selectFirstMatch();
 };
 
 #endif // KEEPASSX_AUTOTYPESELECTVIEW_H

--- a/src/core/AutoTypeMatch.cpp
+++ b/src/core/AutoTypeMatch.cpp
@@ -15,35 +15,24 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSX_AUTOTYPESELECTDIALOG_H
-#define KEEPASSX_AUTOTYPESELECTDIALOG_H
+#include "AutoTypeMatch.h"
 
-#include <QAbstractItemModel>
-#include <QDialog>
-#include <QHash>
+AutoTypeMatch::AutoTypeMatch()
+  : entry(Q_NULLPTR),
+    sequence()
+{}
 
-#include "core/Global.h"
-#include "core/AutoTypeMatch.h"
+AutoTypeMatch::AutoTypeMatch(Entry* entry, QString sequence)
+  : entry(entry),
+    sequence(sequence)
+{}
 
-class AutoTypeSelectView;
-
-class AutoTypeSelectDialog : public QDialog
+bool AutoTypeMatch::operator==(const AutoTypeMatch& other) const
 {
-    Q_OBJECT
+    return entry == other.entry && sequence == other.sequence;
+}
 
-public:
-    explicit AutoTypeSelectDialog(QWidget* parent = Q_NULLPTR);
-    void setMatchList(const QList<AutoTypeMatch>& matchList);
-
-Q_SIGNALS:
-    void matchActivated(AutoTypeMatch match);
-
-private Q_SLOTS:
-    void emitMatchActivated(const QModelIndex& index);
-
-private:
-    AutoTypeSelectView* const m_view;
-    bool m_matchActivatedEmitted;
-};
-
-#endif // KEEPASSX_AUTOTYPESELECTDIALOG_H
+bool AutoTypeMatch::operator!=(const AutoTypeMatch& other) const
+{
+    return entry != other.entry || sequence != other.sequence;
+}

--- a/src/core/AutoTypeMatch.h
+++ b/src/core/AutoTypeMatch.h
@@ -15,35 +15,28 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSX_AUTOTYPESELECTDIALOG_H
-#define KEEPASSX_AUTOTYPESELECTDIALOG_H
+#ifndef KEEPASSX_AUTOTYPEMATCH_H
+#define KEEPASSX_AUTOTYPEMATCH_H
 
-#include <QAbstractItemModel>
-#include <QDialog>
-#include <QHash>
+#include <QObject>
+#include <QString>
 
 #include "core/Global.h"
-#include "core/AutoTypeMatch.h"
 
-class AutoTypeSelectView;
+class Entry;
 
-class AutoTypeSelectDialog : public QDialog
+struct AutoTypeMatch
 {
-    Q_OBJECT
+    Entry* entry;
+    QString sequence;
 
-public:
-    explicit AutoTypeSelectDialog(QWidget* parent = Q_NULLPTR);
-    void setMatchList(const QList<AutoTypeMatch>& matchList);
+    AutoTypeMatch();
+    AutoTypeMatch(Entry* entry, QString sequence);
 
-Q_SIGNALS:
-    void matchActivated(AutoTypeMatch match);
-
-private Q_SLOTS:
-    void emitMatchActivated(const QModelIndex& index);
-
-private:
-    AutoTypeSelectView* const m_view;
-    bool m_matchActivatedEmitted;
+    bool operator==(const AutoTypeMatch& other) const;
+    bool operator!=(const AutoTypeMatch& other) const;
 };
 
-#endif // KEEPASSX_AUTOTYPESELECTDIALOG_H
+Q_DECLARE_TYPEINFO(AutoTypeMatch, Q_MOVABLE_TYPE);
+
+#endif // KEEPASSX_AUTOTYPEMATCH_H

--- a/src/gui/entry/AutoTypeMatchModel.cpp
+++ b/src/gui/entry/AutoTypeMatchModel.cpp
@@ -1,0 +1,136 @@
+/*
+ *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AutoTypeMatchModel.h"
+
+#include <QFont>
+
+#include "core/DatabaseIcons.h"
+#include "core/Entry.h"
+#include "core/Group.h"
+
+AutoTypeMatchModel::AutoTypeMatchModel(QObject* parent)
+    : QAbstractTableModel(parent)
+{
+}
+
+AutoTypeMatch AutoTypeMatchModel::matchFromIndex(const QModelIndex& index) const
+{
+    Q_ASSERT(index.isValid() && index.row() < m_matches.size());
+    return m_matches.at(index.row());
+}
+
+QModelIndex AutoTypeMatchModel::indexFromMatch(AutoTypeMatch match) const
+{
+    int row = m_matches.indexOf(match);
+    Q_ASSERT(row != -1);
+    return index(row, 1);
+}
+
+void AutoTypeMatchModel::setMatchList(const QList<AutoTypeMatch>& matches)
+{
+    beginResetModel();
+    m_matches = matches;
+    endResetModel();
+}
+
+int AutoTypeMatchModel::rowCount(const QModelIndex& parent) const
+{
+    if (parent.isValid()) {
+        return 0;
+    }
+    else {
+        return m_matches.size();
+    }
+}
+
+int AutoTypeMatchModel::columnCount(const QModelIndex& parent) const
+{
+    Q_UNUSED(parent);
+
+    return 4;
+}
+
+QVariant AutoTypeMatchModel::data(const QModelIndex& index, int role) const
+{
+    if (!index.isValid()) {
+        return QVariant();
+    }
+
+    AutoTypeMatch match = matchFromIndex(index);
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case ParentGroup:
+            if (match.entry->group()) {
+                return match.entry->group()->name();
+            }
+            break;
+        case Title:
+            return match.entry->title();
+        case Username:
+            return match.entry->username();
+        case Sequence:
+            return match.sequence;
+        }
+    }
+    else if (role == Qt::DecorationRole) {
+        switch (index.column()) {
+        case ParentGroup:
+            if (match.entry->group()) {
+                return match.entry->group()->iconPixmap();
+            }
+            break;
+        case Title:
+            if (match.entry->isExpired()) {
+                return databaseIcons()->iconPixmap(DatabaseIcons::ExpiredIconIndex);
+            }
+            else {
+                return match.entry->iconPixmap();
+            }
+        }
+    }
+    else if (role == Qt::FontRole) {
+        QFont font;
+        if (match.entry->isExpired()) {
+            font.setStrikeOut(true);
+        }
+        return font;
+    }
+
+    return QVariant();
+}
+
+QVariant AutoTypeMatchModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (orientation == Qt::Horizontal && role == Qt::DisplayRole) {
+        switch (section) {
+        case ParentGroup:
+            return tr("Group");
+        case Title:
+            return tr("Title");
+        case Username:
+            return tr("Username");
+        case Sequence:
+            return tr("Sequence");
+        }
+    }
+
+    return QVariant();
+}
+
+

--- a/src/gui/entry/AutoTypeMatchModel.h
+++ b/src/gui/entry/AutoTypeMatchModel.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSX_AUTOTYPEMATCHMODEL_H
+#define KEEPASSX_AUTOTYPEMATCHMODEL_H
+
+#include <QAbstractTableModel>
+
+#include "core/Global.h"
+#include "core/AutoTypeMatch.h"
+
+class AutoTypeMatchModel : public QAbstractTableModel
+{
+    Q_OBJECT
+
+public:
+    enum ModelColumn
+    {
+        ParentGroup = 0,
+        Title = 1,
+        Username = 2,
+        Sequence = 3
+    };
+
+    explicit AutoTypeMatchModel(QObject* parent = Q_NULLPTR);
+    AutoTypeMatch matchFromIndex(const QModelIndex& index) const;
+    QModelIndex indexFromMatch(AutoTypeMatch match) const;
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const Q_DECL_OVERRIDE;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const Q_DECL_OVERRIDE;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+
+    void setMatchList(const QList<AutoTypeMatch>& matches);
+
+private:
+    QList<AutoTypeMatch> m_matches;
+};
+
+#endif // KEEPASSX_AUTOTYPEMATCHMODEL_H

--- a/src/gui/entry/AutoTypeMatchView.cpp
+++ b/src/gui/entry/AutoTypeMatchView.cpp
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AutoTypeMatchView.h"
+
+#include <QHeaderView>
+#include <QKeyEvent>
+
+#include "gui/SortFilterHideProxyModel.h"
+
+AutoTypeMatchView::AutoTypeMatchView(QWidget* parent)
+    : QTreeView(parent)
+    , m_model(new AutoTypeMatchModel(this))
+    , m_sortModel(new SortFilterHideProxyModel(this))
+{
+    m_sortModel->setSourceModel(m_model);
+    m_sortModel->setDynamicSortFilter(true);
+    m_sortModel->setSortLocaleAware(true);
+    m_sortModel->setSortCaseSensitivity(Qt::CaseInsensitive);
+    QTreeView::setModel(m_sortModel);
+
+    setUniformRowHeights(true);
+    setRootIsDecorated(false);
+    setAlternatingRowColors(true);
+    setDragEnabled(false);
+    setSortingEnabled(true);
+    setSelectionMode(QAbstractItemView::SingleSelection);
+    header()->setDefaultSectionSize(150);
+
+    connect(this, SIGNAL(doubleClicked(QModelIndex)), SLOT(emitMatchActivated(QModelIndex)));
+    connect(selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)), SIGNAL(matchSelectionChanged()));
+}
+
+void AutoTypeMatchView::keyPressEvent(QKeyEvent* event)
+{
+    if ((event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) && currentIndex().isValid()) {
+        emitMatchActivated(currentIndex());
+    }
+
+    QTreeView::keyPressEvent(event);
+}
+
+void AutoTypeMatchView::setMatchList(const QList<AutoTypeMatch>& matches)
+{
+    m_model->setMatchList(matches);
+    for (int i = 0; i < m_model->columnCount(); ++i) {
+        resizeColumnToContents(i);
+        if (columnWidth(i) > 250) {
+          setColumnWidth(i, 250);
+        }
+    }
+    setFirstMatchActive();
+}
+
+void AutoTypeMatchView::setFirstMatchActive()
+{
+    if(m_model->rowCount() > 0) {
+        QModelIndex index = m_sortModel->mapToSource(m_sortModel->index(0, 0));
+        setCurrentMatch(m_model->matchFromIndex(index));
+    }
+    else {
+        Q_EMIT matchSelectionChanged();
+    }
+}
+
+void AutoTypeMatchView::emitMatchActivated(const QModelIndex& index)
+{
+    AutoTypeMatch match = matchFromIndex(index);
+
+    Q_EMIT matchActivated(match);
+}
+
+void AutoTypeMatchView::setModel(QAbstractItemModel* model)
+{
+    Q_UNUSED(model);
+    Q_ASSERT(false);
+}
+
+AutoTypeMatch AutoTypeMatchView::currentMatch()
+{
+    QModelIndexList list = selectionModel()->selectedRows();
+    if (list.size() == 1) {
+        return m_model->matchFromIndex(m_sortModel->mapToSource(list.first()));
+    }
+    else {
+        return AutoTypeMatch();
+    }
+}
+
+void AutoTypeMatchView::setCurrentMatch(AutoTypeMatch match)
+{
+    selectionModel()->setCurrentIndex(m_sortModel->mapFromSource(m_model->indexFromMatch(match)),
+                                      QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+}
+
+AutoTypeMatch AutoTypeMatchView::matchFromIndex(const QModelIndex& index)
+{
+    if (index.isValid()) {
+        return m_model->matchFromIndex(m_sortModel->mapToSource(index));
+    }
+    else {
+        return AutoTypeMatch();
+    }
+}
+

--- a/src/gui/entry/AutoTypeMatchView.h
+++ b/src/gui/entry/AutoTypeMatchView.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,35 +15,44 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSX_AUTOTYPESELECTDIALOG_H
-#define KEEPASSX_AUTOTYPESELECTDIALOG_H
+#ifndef KEEPASSX_AUTOTYPEMATCHVIEW_H
+#define KEEPASSX_AUTOTYPEMATCHVIEW_H
 
-#include <QAbstractItemModel>
-#include <QDialog>
-#include <QHash>
+#include <QTreeView>
 
 #include "core/Global.h"
 #include "core/AutoTypeMatch.h"
 
-class AutoTypeSelectView;
+#include "gui/entry/AutoTypeMatchModel.h"
 
-class AutoTypeSelectDialog : public QDialog
+class SortFilterHideProxyModel;
+
+class AutoTypeMatchView : public QTreeView
 {
     Q_OBJECT
 
 public:
-    explicit AutoTypeSelectDialog(QWidget* parent = Q_NULLPTR);
-    void setMatchList(const QList<AutoTypeMatch>& matchList);
+    explicit AutoTypeMatchView(QWidget* parent = Q_NULLPTR);
+    void setModel(QAbstractItemModel* model) Q_DECL_OVERRIDE;
+    AutoTypeMatch currentMatch();
+    void setCurrentMatch(AutoTypeMatch match);
+    AutoTypeMatch matchFromIndex(const QModelIndex& index);
+    void setMatchList(const QList<AutoTypeMatch>& matches);
+    void setFirstMatchActive();
 
 Q_SIGNALS:
     void matchActivated(AutoTypeMatch match);
+    void matchSelectionChanged();
+
+protected:
+    void keyPressEvent(QKeyEvent* event) Q_DECL_OVERRIDE;
 
 private Q_SLOTS:
     void emitMatchActivated(const QModelIndex& index);
 
 private:
-    AutoTypeSelectView* const m_view;
-    bool m_matchActivatedEmitted;
+    AutoTypeMatchModel* const m_model;
+    SortFilterHideProxyModel* const m_sortModel;
 };
 
-#endif // KEEPASSX_AUTOTYPESELECTDIALOG_H
+#endif // KEEPASSX_AUTOTYPEMATCHVIEW_H


### PR DESCRIPTION
This adds support for choosing between multiple auto-type sequences for an entry if more than one matches, including adding a new model+view so that the auto-type select dialog displays what the auto-type sequence is. This more closely matches Keepass's behavior here.

(Motivated by switching from Keepass and finding global-autotype became unusable with my setup since I wouldn't be able to see whether username+password vs just password was about to be entered, or be able to choose between them).
