### PR TITLE
Made the build directory always present, but still always empty.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
+### CMake ###
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Makefile
+cmake_install.cmake
+install_manifest.txt
 CMakeLists.txt.*
-build/
+

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ sudo apt-get install build-essential cmake qtbase5-dev libqt5x11extras5-dev qtto
 To compile from source:
 
 ```bash
-mkdir build
-cd build
+git clone https://github.com/keepassx/keepassx.git
+cd keepassx/build
 cmake ..
 make [-jX]
 ```

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Made the build directory always present, but still always empty.

Changed the README.md accordingly. Also added a proper list of CMake temporary files to the root .gitignore and the file build/.gitignore to keep the build folder present but always empty.