### PR TITLE
Adds 'close to tray' option in settings

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -431,6 +431,13 @@ void MainWindow::databaseTabChanged(int tabIndex)
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
+
+  if (config()->get("GUI/CloseToTray").toBool()) {
+    event->ignore();
+    QTimer::singleShot(0, this, SLOT(hide()));
+  }
+  else {
+
     bool accept = saveLastDatabases();
 
     if (accept) {
@@ -442,6 +449,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
     else {
         event->ignore();
     }
+  }
 }
 
 void MainWindow::changeEvent(QEvent* event)

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -45,6 +45,7 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     // systray not useful on OS X
     m_generalUi->systrayShowCheckBox->setVisible(false);
     m_generalUi->systrayMinimizeToTrayCheckBox->setVisible(false);
+    m_generalUi->systrayCloseToTrayCheckBox->setVisible(false);
 #endif
 
     connect(this, SIGNAL(accepted()), SLOT(saveSettings()));
@@ -54,6 +55,8 @@ SettingsWidget::SettingsWidget(QWidget* parent)
             this, SLOT(enableAutoSaveOnExit(bool)));
     connect(m_generalUi->systrayShowCheckBox, SIGNAL(toggled(bool)),
             m_generalUi->systrayMinimizeToTrayCheckBox, SLOT(setEnabled(bool)));
+    connect(m_generalUi->systrayShowCheckBox, SIGNAL(toggled(bool)),
+            m_generalUi->systrayCloseToTrayCheckBox, SLOT(setEnabled(bool)));
 
     connect(m_secUi->clearClipboardCheckBox, SIGNAL(toggled(bool)),
             m_secUi->clearClipboardSpinBox, SLOT(setEnabled(bool)));
@@ -89,6 +92,7 @@ void SettingsWidget::loadSettings()
 
     m_generalUi->systrayShowCheckBox->setChecked(config()->get("GUI/ShowTrayIcon").toBool());
     m_generalUi->systrayMinimizeToTrayCheckBox->setChecked(config()->get("GUI/MinimizeToTray").toBool());
+    m_generalUi->systrayCloseToTrayCheckBox->setChecked(config()->get("GUI/CloseToTray").toBool());
 
     if (autoType()->isAvailable()) {
         m_globalAutoTypeKey = static_cast<Qt::Key>(config()->get("GlobalAutoTypeKey").toInt());
@@ -130,6 +134,7 @@ void SettingsWidget::saveSettings()
 
     config()->set("GUI/ShowTrayIcon", m_generalUi->systrayShowCheckBox->isChecked());
     config()->set("GUI/MinimizeToTray", m_generalUi->systrayMinimizeToTrayCheckBox->isChecked());
+    config()->set("GUI/CloseToTray", m_generalUi->systrayCloseToTrayCheckBox->isChecked());
 
     if (autoType()->isAvailable()) {
         config()->set("GlobalAutoTypeKey", m_generalUi->autoTypeShortcutWidget->key());

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -113,6 +113,16 @@
      </property>
     </widget>
    </item>
+   <item row="12" column="0">
+    <widget class="QCheckBox" name="systrayCloseToTrayCheckBox">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Hide window to system tray when closing main window (Use Ctrl+Q or Database -> Exit to exit).</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>


### PR DESCRIPTION
_**WIP**_
(see https://www.keepassx.org/dev/issues/364#change-1035)

I'd like to add this functionality, however i can not manually test this, as it seems like assets like icons and images are not properly loaded when i run the compiled version (e.g. i see the alternative caption "Add new entry" in the menu bar instead of its icon). The try icon is not displayed at all.

I'm not that familiar with C/Qt development, so any hints are very much appreciated.

Good work, by the way!
