### PR TITLE
Break special characters option into more options.

### DIFF
--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -135,7 +135,7 @@ QVector<PasswordGroup> PasswordGenerator::passwordGroups() const
 
         passwordGroups.append(group);
     }
-    if (m_classes & Numbers) {
+    if (m_classes & Digits) {
         PasswordGroup group;
 
         for (int i = 48; i < (48 + 10); i++) {
@@ -148,28 +148,58 @@ QVector<PasswordGroup> PasswordGenerator::passwordGroups() const
 
         passwordGroups.append(group);
     }
-    if (m_classes & SpecialCharacters) {
+    if (m_classes & Minus) {
+        PasswordGroup group;
+        group.append(45);
+        passwordGroups.append(group);
+    }
+    if (m_classes & Underlines) {
+        PasswordGroup group;
+        group.append(95);
+        passwordGroups.append(group);
+    }
+    if (m_classes & Spaces) {
+        PasswordGroup group;
+        group.append(32);
+        passwordGroups.append(group);
+    }
+    if (m_classes & Specials) {
         PasswordGroup group;
 
         for (int i = 33; i <= 47; i++) {
+            // Skip open/closed parenthesis and minus
+            if ((i == 40) || (i == 41) || (i == 45))
+                continue;
             group.append(i);
         }
 
         for (int i = 58; i <= 64; i++) {
-            group.append(i);
-        }
-
-        for (int i = 91; i <= 96; i++) {
-            group.append(i);
-        }
-
-        for (int i = 123; i <= 126; i++) {
-            if ((m_flags & ExcludeLookAlike) && (i == 124)) { // "|"
+            // Skip angle brackets
+            if ((i == 60) || (i == 62))
                 continue;
-            }
-
             group.append(i);
         }
+
+        // Backslash, Caret, and Grave accent
+        for (int i = 92; i <= 96; i+=2) {
+            group.append(i);
+        }
+
+        if (!(m_flags & ExcludeLookAlike))
+            group.append(124);
+        group.append(126);
+
+        passwordGroups.append(group);
+    }
+    if (m_classes & Brackets) {
+        PasswordGroup group;
+
+        group.append(60);
+        group.append(62);
+        group.append(91);
+        group.append(93);
+        group.append(123);
+        group.append(125);
 
         passwordGroups.append(group);
     }
@@ -187,10 +217,22 @@ int PasswordGenerator::numCharClasses() const
     if (m_classes & UpperLetters) {
         numClasses++;
     }
-    if (m_classes & Numbers) {
+    if (m_classes & Digits) {
         numClasses++;
     }
-    if (m_classes & SpecialCharacters) {
+    if (m_classes & Minus) {
+        numClasses++;
+    }
+    if (m_classes & Underlines) {
+        numClasses++;
+    }
+    if (m_classes & Spaces) {
+        numClasses++;
+    }
+    if (m_classes & Specials) {
+        numClasses++;
+    }
+    if (m_classes & Brackets) {
         numClasses++;
     }
 

--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -31,8 +31,12 @@ public:
     {
         LowerLetters      = 0x1,
         UpperLetters      = 0x2,
-        Numbers           = 0x4,
-        SpecialCharacters = 0x8
+        Digits            = 0x4,
+        Minus             = 0x8,
+        Underlines        = 0x10,
+        Spaces            = 0x20,
+        Specials          = 0x40,
+        Brackets          = 0x80
     };
     Q_DECLARE_FLAGS(CharClasses, CharClass)
 

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -56,10 +56,14 @@ PasswordGeneratorWidget::~PasswordGeneratorWidget()
 
 void PasswordGeneratorWidget::loadSettings()
 {
-    m_ui->checkBoxLower->setChecked(config()->get("generator/LowerCase", true).toBool());
-    m_ui->checkBoxUpper->setChecked(config()->get("generator/UpperCase", true).toBool());
-    m_ui->checkBoxNumbers->setChecked(config()->get("generator/Numbers", true).toBool());
-    m_ui->checkBoxSpecialChars->setChecked(config()->get("generator/SpecialChars", false).toBool());
+    m_ui->checkBoxBrackets->setChecked(config()->get("generator/Brackets", false).toBool());
+    m_ui->checkBoxDigits->setChecked(config()->get("generator/Digits", true).toBool());
+    m_ui->checkBoxLowers->setChecked(config()->get("generator/LowerCase", true).toBool());
+    m_ui->checkBoxMinus->setChecked(config()->get("generator/Minus", true).toBool());
+    m_ui->checkBoxSpaces->setChecked(config()->get("generator/Spaces", false).toBool());
+    m_ui->checkBoxSpecials->setChecked(config()->get("generator/Specials", false).toBool());
+    m_ui->checkBoxUnderlines->setChecked(config()->get("generator/Underlines", true).toBool());
+    m_ui->checkBoxUppers->setChecked(config()->get("generator/UpperCase", true).toBool());
 
     m_ui->checkBoxExcludeAlike->setChecked(config()->get("generator/ExcludeAlike", true).toBool());
     m_ui->checkBoxEnsureEvery->setChecked(config()->get("generator/EnsureEvery", true).toBool());
@@ -69,10 +73,14 @@ void PasswordGeneratorWidget::loadSettings()
 
 void PasswordGeneratorWidget::saveSettings()
 {
-    config()->set("generator/LowerCase", m_ui->checkBoxLower->isChecked());
-    config()->set("generator/UpperCase", m_ui->checkBoxUpper->isChecked());
-    config()->set("generator/Numbers", m_ui->checkBoxNumbers->isChecked());
-    config()->set("generator/SpecialChars", m_ui->checkBoxSpecialChars->isChecked());
+    config()->set("generator/Brackets", m_ui->checkBoxBrackets->isChecked());
+    config()->set("generator/Digits", m_ui->checkBoxDigits->isChecked());
+    config()->set("generator/LowerCase", m_ui->checkBoxLowers->isChecked());
+    config()->set("generator/Minus", m_ui->checkBoxMinus->isChecked());
+    config()->set("generator/Spaces", m_ui->checkBoxSpaces->isChecked());
+    config()->set("generator/Specials", m_ui->checkBoxSpecials->isChecked());
+    config()->set("generator/Underlines", m_ui->checkBoxUnderlines->isChecked());
+    config()->set("generator/UpperCase", m_ui->checkBoxUppers->isChecked());
 
     config()->set("generator/ExcludeAlike", m_ui->checkBoxExcludeAlike->isChecked());
     config()->set("generator/EnsureEvery", m_ui->checkBoxEnsureEvery->isChecked());
@@ -125,20 +133,36 @@ PasswordGenerator::CharClasses PasswordGeneratorWidget::charClasses()
 {
     PasswordGenerator::CharClasses classes;
 
-    if (m_ui->checkBoxLower->isChecked()) {
+    if (m_ui->checkBoxBrackets->isChecked()) {
+        classes |= PasswordGenerator::Brackets;
+    }
+
+    if (m_ui->checkBoxDigits->isChecked()) {
+        classes |= PasswordGenerator::Digits;
+    }
+
+    if (m_ui->checkBoxLowers->isChecked()) {
         classes |= PasswordGenerator::LowerLetters;
     }
 
-    if (m_ui->checkBoxUpper->isChecked()) {
+    if (m_ui->checkBoxMinus->isChecked()) {
+        classes |= PasswordGenerator::Minus;
+    }
+
+    if (m_ui->checkBoxSpaces->isChecked()) {
+        classes |= PasswordGenerator::Spaces;
+    }
+
+    if (m_ui->checkBoxSpecials->isChecked()) {
+        classes |= PasswordGenerator::Specials;
+    }
+
+    if (m_ui->checkBoxUnderlines->isChecked()) {
+        classes |= PasswordGenerator::Underlines;
+    }
+
+    if (m_ui->checkBoxUppers->isChecked()) {
         classes |= PasswordGenerator::UpperLetters;
-    }
-
-    if (m_ui->checkBoxNumbers->isChecked()) {
-        classes |= PasswordGenerator::Numbers;
-    }
-
-    if (m_ui->checkBoxSpecialChars->isChecked()) {
-        classes |= PasswordGenerator::SpecialCharacters;
     }
 
     return classes;

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>434</width>
-    <height>250</height>
+    <width>505</width>
+    <height>336</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -93,85 +93,107 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="QToolButton" name="checkBoxUpper">
-          <property name="toolTip">
-           <string>Upper Case Letters</string>
-          </property>
-          <property name="text">
-           <string notr="true">A-Z</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">optionButtons</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="checkBoxLower">
-          <property name="toolTip">
-           <string>Lower Case Letters</string>
-          </property>
-          <property name="text">
-           <string notr="true">a-z</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">optionButtons</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="checkBoxNumbers">
-          <property name="toolTip">
-           <string>Numbers</string>
-          </property>
-          <property name="text">
-           <string notr="true">0-9</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">optionButtons</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="checkBoxSpecialChars">
-          <property name="toolTip">
-           <string>Special Characters</string>
-          </property>
-          <property name="text">
-           <string notr="true">/*_&amp; ...</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">optionButtons</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
+       <layout class="QGridLayout" name="gridLayout_3">
+        <item row="1" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayoutLeft">
+            <item>
+             <widget class="QCheckBox" name="checkBoxUppers">
+              <property name="text">
+               <string>Upper Case ( A - Z )</string>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">optionButtons</string>
+              </attribute>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkBoxLowers">
+              <property name="text">
+               <string>Lower Case ( a - z )</string>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">optionButtons</string>
+              </attribute>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkBoxMinus">
+              <property name="text">
+               <string>Minus ( - )</string>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">optionButtons</string>
+              </attribute>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkBoxDigits">
+              <property name="text">
+               <string>Digits ( 0 - 9 )</string>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">optionButtons</string>
+              </attribute>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayoutRight">
+            <item>
+             <widget class="QCheckBox" name="checkBoxUnderlines">
+              <property name="text">
+               <string>Underline ( _ )</string>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">optionButtons</string>
+              </attribute>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkBoxSpaces">
+              <property name="text">
+               <string>Space (  )</string>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">optionButtons</string>
+              </attribute>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkBoxSpecials">
+              <property name="text">
+               <string>Special ( ! @ # $ ... )</string>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">optionButtons</string>
+              </attribute>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkBoxBrackets">
+              <property name="text">
+               <string>Brackets ( &lt; &gt; { } [ ] ( ) )</string>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">optionButtons</string>
+              </attribute>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
         </item>
        </layout>
+      </item>
+      <item>
+       <widget class="Line" name="line">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="checkBoxExcludeAlike">
@@ -237,10 +259,14 @@
   <tabstop>togglePasswordButton</tabstop>
   <tabstop>sliderLength</tabstop>
   <tabstop>spinBoxLength</tabstop>
-  <tabstop>checkBoxUpper</tabstop>
-  <tabstop>checkBoxLower</tabstop>
-  <tabstop>checkBoxNumbers</tabstop>
-  <tabstop>checkBoxSpecialChars</tabstop>
+  <tabstop>checkBoxUppers</tabstop>
+  <tabstop>checkBoxLowers</tabstop>
+  <tabstop>checkBoxMinus</tabstop>
+  <tabstop>checkBoxDigits</tabstop>
+  <tabstop>checkBoxUnderlines</tabstop>
+  <tabstop>checkBoxSpaces</tabstop>
+  <tabstop>checkBoxSpecials</tabstop>
+  <tabstop>checkBoxBrackets</tabstop>
   <tabstop>checkBoxExcludeAlike</tabstop>
   <tabstop>checkBoxEnsureEvery</tabstop>
   <tabstop>buttonApply</tabstop>

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>505</width>
-    <height>336</height>
+    <height>345</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -119,9 +119,9 @@
              </widget>
             </item>
             <item>
-             <widget class="QCheckBox" name="checkBoxMinus">
+             <widget class="QCheckBox" name="checkBoxDigits">
               <property name="text">
-               <string>Minus ( - )</string>
+               <string>Digits ( 0 - 9 )</string>
               </property>
               <attribute name="buttonGroup">
                <string notr="true">optionButtons</string>
@@ -129,9 +129,9 @@
              </widget>
             </item>
             <item>
-             <widget class="QCheckBox" name="checkBoxDigits">
+             <widget class="QCheckBox" name="checkBoxMinus">
               <property name="text">
-               <string>Digits ( 0 - 9 )</string>
+               <string>Minus ( - )</string>
               </property>
               <attribute name="buttonGroup">
                <string notr="true">optionButtons</string>
@@ -262,7 +262,6 @@
   <tabstop>checkBoxUppers</tabstop>
   <tabstop>checkBoxLowers</tabstop>
   <tabstop>checkBoxMinus</tabstop>
-  <tabstop>checkBoxDigits</tabstop>
   <tabstop>checkBoxUnderlines</tabstop>
   <tabstop>checkBoxSpaces</tabstop>
   <tabstop>checkBoxSpecials</tabstop>


### PR DESCRIPTION
When generating a new password, the special character option is now broken into a few more options.  Space, minus sign, brackets, underline, and the rest of the special characters are now available for selection.  This was done because some websites arbitrarily limit the kinds of special characters used in passwords.
