### PR TITLE
make password gen slider go to 200

### DIFF
--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -59,7 +59,7 @@
           <number>1</number>
          </property>
          <property name="maximum">
-          <number>64</number>
+          <number>200</number>
          </property>
          <property name="orientation">
           <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
I don't know if there were any rational to the original 64 max, but if not I would suggest to rise it. Mostly because it seems unnecessary to have the perceived max at 64 which is relatively low.

I don't have too much rational to this other that it is higher, and it seemed kind of silly to bump it to just 100.