### PR TITLE
Link directly to new issue list and new issue form in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ or would like to suggest a completely new feature for KeePassX, please file a ti
 
 ### Bug Reports
 
-Our software isn't always perfect, but we strive to always improve our work. You may file bug reports on the [KeePassX development](https://www.keepassx.org/dev/) site.
+Our software isn't always perfect, but we strive to always improve our work.
+You can view existing bugs [here](https://www.keepassx.org/dev/projects/keepassx/issue) and file new bugs [here](https://www.keepassx.org/dev/projects/keepassx/issues/new).
 
 ### Pull Requests
 


### PR DESCRIPTION
Users (like me) coming from github might not know where to file new issues on the redmine site. This helps.