### PR TITLE
introduced config option to open databases read only

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -106,6 +106,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("GUI/Language", "system");
     m_defaults.insert("GUI/ShowTrayIcon", false);
     m_defaults.insert("GUI/MinimizeToTray", false);
+    m_defaults.insert("OpenReadOnly", false);
 }
 
 Config* Config::instance()

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -55,6 +55,9 @@ public:
     ~DatabaseTabWidget();
     void openDatabase(const QString& fileName, const QString& pw = QString(),
                       const QString& keyFile = QString());
+    void openDatabase(const QString& fileName, const bool& openReadOnly,
+                      const QString& pw = QString(),
+                      const QString& keyFile = QString());
     DatabaseWidget* currentDatabaseWidget();
     bool hasLockableDatabases() const;
 


### PR DESCRIPTION
Let all databases open read only by the boolean config file entry OpenReadOnly