### PR TITLE
Add setting to match URL for auto-type

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -530,6 +530,12 @@ QString AutoType::autoTypeSequence(const Entry* entry, const QString& windowTitl
             match = true;
         }
 
+        if (!match && config()->get("AutoTypeEntryUrlMatch").toBool() && !entry->url().isEmpty()
+                && windowTitle.contains(entry->url(), Qt::CaseInsensitive)) {
+            sequence = entry->defaultAutoTypeSequence();
+            match = true;
+        }
+
         if (!match) {
             return QString();
         }

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -97,6 +97,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("MinimizeOnCopy", false);
     m_defaults.insert("UseGroupIconOnEntryCreation", false);
     m_defaults.insert("AutoTypeEntryTitleMatch", true);
+    m_defaults.insert("AutoTypeEntryUrlMatch", false);
     m_defaults.insert("security/clearclipboard", true);
     m_defaults.insert("security/clearclipboardtimeout", 10);
     m_defaults.insert("security/lockdatabaseidle", false);

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -76,6 +76,7 @@ void SettingsWidget::loadSettings()
     m_generalUi->minimizeOnCopyCheckBox->setChecked(config()->get("MinimizeOnCopy").toBool());
     m_generalUi->useGroupIconOnEntryCreationCheckBox->setChecked(config()->get("UseGroupIconOnEntryCreation").toBool());
     m_generalUi->autoTypeEntryTitleMatchCheckBox->setChecked(config()->get("AutoTypeEntryTitleMatch").toBool());
+    m_generalUi->autoTypeEntryUrlMatchCheckBox->setChecked(config()->get("AutoTypeEntryUrlMatch").toBool());
 
     m_generalUi->languageComboBox->clear();
     QList<QPair<QString, QString> > languages = Translator::availableLanguages();
@@ -125,6 +126,8 @@ void SettingsWidget::saveSettings()
                   m_generalUi->useGroupIconOnEntryCreationCheckBox->isChecked());
     config()->set("AutoTypeEntryTitleMatch",
                   m_generalUi->autoTypeEntryTitleMatchCheckBox->isChecked());
+    config()->set("AutoTypeEntryUrlMatch",
+                  m_generalUi->autoTypeEntryUrlMatchCheckBox->isChecked());
     int currentLangIndex = m_generalUi->languageComboBox->currentIndex();
     config()->set("GUI/Language", m_generalUi->languageComboBox->itemData(currentLangIndex).toString());
 

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -87,23 +87,30 @@
     </widget>
    </item>
    <item row="9" column="0">
+    <widget class="QCheckBox" name="autoTypeEntryUrlMatchCheckBox">
+     <property name="text">
+      <string>Use entry URL to match windows for global auto-type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
     <widget class="QLabel" name="languageLabel">
      <property name="text">
       <string>Language</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
+   <item row="10" column="1">
     <widget class="QComboBox" name="languageComboBox"/>
    </item>
-   <item row="10" column="0">
+   <item row="11" column="0">
     <widget class="QCheckBox" name="systrayShowCheckBox">
      <property name="text">
       <string>Show a system tray icon</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="0">
+   <item row="12" column="0">
     <widget class="QCheckBox" name="systrayMinimizeToTrayCheckBox">
      <property name="enabled">
       <bool>false</bool>

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -55,6 +55,7 @@ void TestAutoType::initTestCase()
 void TestAutoType::init()
 {
     config()->set("AutoTypeEntryTitleMatch", false);
+    config()->set("AutoTypeEntryUrlMatch", false);
     m_test->clearActions();
 
     m_db = new Database();
@@ -77,6 +78,7 @@ void TestAutoType::init()
     m_entry2->setGroup(m_group);
     m_entry2->setPassword("myuser");
     m_entry2->setTitle("entry title");
+    m_entry2->setUrl("https://test.url");
 
     m_entry3 = new Entry();
     m_entry3->setGroup(m_group);
@@ -158,9 +160,20 @@ void TestAutoType::testGlobalAutoTypeTitleMatch()
              QString("%1%2").arg(m_entry2->password(), m_test->keyToString(Qt::Key_Enter)));
 }
 
+void TestAutoType::testGlobalAutoTypeUrlMatch()
+{
+    config()->set("AutoTypeEntryUrlMatch", true);
+
+    m_test->setActiveWindowTitle("An Entry Title! (https://test.url)");
+    m_autoType->performGlobalAutoType(m_dbList);
+
+    QCOMPARE(m_test->actionChars(),
+             QString("%1%2").arg(m_entry2->password(), m_test->keyToString(Qt::Key_Enter)));
+}
+
 void TestAutoType::testGlobalAutoTypeTitleMatchDisabled()
 {
-    m_test->setActiveWindowTitle("An Entry Title!");
+    m_test->setActiveWindowTitle("An Entry Title! (https://test.url)");
     MessageBox::setNextAnswer(QMessageBox::Ok);
     m_autoType->performGlobalAutoType(m_dbList);
 

--- a/tests/TestAutoType.h
+++ b/tests/TestAutoType.h
@@ -42,6 +42,7 @@ private Q_SLOTS:
     void testGlobalAutoTypeWithNoMatch();
     void testGlobalAutoTypeWithOneMatch();
     void testGlobalAutoTypeTitleMatch();
+    void testGlobalAutoTypeUrlMatch();
     void testGlobalAutoTypeTitleMatchDisabled();
     void testGlobalAutoTypeRegExp();
 


### PR DESCRIPTION
I use a browser extension that puts the full URL in the window title and often the 'title' entry in keepass is not in the URL.
This patch adds an option to also compare the entry URL to the window title.
(keepass has the same option)
