### PR TITLE
Add "close window to tray" option

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -173,7 +173,7 @@ MainWindow::MainWindow()
             SLOT(exportToCsv()));
     connect(m_ui->actionLockDatabases, SIGNAL(triggered()), m_ui->tabWidget,
             SLOT(lockDatabases()));
-    connect(m_ui->actionQuit, SIGNAL(triggered()), SLOT(close()));
+    connect(m_ui->actionQuit, SIGNAL(triggered()), SLOT(tryToQuit()));
 
     m_actionMultiplexer.connect(m_ui->actionEntryNew, SIGNAL(triggered()),
             SLOT(createEntry()));
@@ -438,17 +438,29 @@ void MainWindow::databaseTabChanged(int tabIndex)
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
-    bool accept = saveLastDatabases();
+    bool accept = true;
+    if (!isTrayIconEnabled() || !m_trayIcon || !m_trayIcon->isVisible()
+            || !config()->get("GUI/CloseToTray").toBool())
+    {
+        accept = tryToQuit();
+    }
 
     if (accept) {
-        saveWindowInformation();
-
         event->accept();
-        QApplication::quit();
     }
     else {
         event->ignore();
     }
+}
+
+bool MainWindow::tryToQuit()
+{
+    bool accept = saveLastDatabases();
+    if (accept) {
+        saveWindowInformation();
+        QApplication::quit();
+    }
+    return accept;
 }
 
 void MainWindow::changeEvent(QEvent* event)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -48,6 +48,7 @@ protected:
      void changeEvent(QEvent* event) override;
 
 private Q_SLOTS:
+    bool tryToQuit();
     void setMenuActionState(DatabaseWidget::Mode mode = DatabaseWidget::None);
     void updateWindowTitle();
     void showAboutDialog();

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -45,6 +45,7 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     // systray not useful on OS X
     m_generalUi->systrayShowCheckBox->setVisible(false);
     m_generalUi->systrayMinimizeToTrayCheckBox->setVisible(false);
+    m_generalUi->systrayCloseToTrayCheckBox->setVisible(false);
 #endif
 
     connect(this, SIGNAL(accepted()), SLOT(saveSettings()));
@@ -54,6 +55,8 @@ SettingsWidget::SettingsWidget(QWidget* parent)
             this, SLOT(enableAutoSaveOnExit(bool)));
     connect(m_generalUi->systrayShowCheckBox, SIGNAL(toggled(bool)),
             m_generalUi->systrayMinimizeToTrayCheckBox, SLOT(setEnabled(bool)));
+    connect(m_generalUi->systrayShowCheckBox, SIGNAL(toggled(bool)),
+            m_generalUi->systrayCloseToTrayCheckBox, SLOT(setEnabled(bool)));
 
     connect(m_secUi->clearClipboardCheckBox, SIGNAL(toggled(bool)),
             m_secUi->clearClipboardSpinBox, SLOT(setEnabled(bool)));
@@ -89,6 +92,7 @@ void SettingsWidget::loadSettings()
 
     m_generalUi->systrayShowCheckBox->setChecked(config()->get("GUI/ShowTrayIcon").toBool());
     m_generalUi->systrayMinimizeToTrayCheckBox->setChecked(config()->get("GUI/MinimizeToTray").toBool());
+    m_generalUi->systrayCloseToTrayCheckBox->setChecked(config()->get("GUI/CloseToTray").toBool());
 
     if (autoType()->isAvailable()) {
         m_globalAutoTypeKey = static_cast<Qt::Key>(config()->get("GlobalAutoTypeKey").toInt());
@@ -130,6 +134,7 @@ void SettingsWidget::saveSettings()
 
     config()->set("GUI/ShowTrayIcon", m_generalUi->systrayShowCheckBox->isChecked());
     config()->set("GUI/MinimizeToTray", m_generalUi->systrayMinimizeToTrayCheckBox->isChecked());
+    config()->set("GUI/CloseToTray", m_generalUi->systrayCloseToTrayCheckBox->isChecked());
 
     if (autoType()->isAvailable()) {
         config()->set("GlobalAutoTypeKey", m_generalUi->autoTypeShortcutWidget->key());

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>456</width>
-    <height>313</height>
+    <width>477</width>
+    <height>417</height>
    </rect>
   </property>
   <layout class="QFormLayout" name="formLayout">
@@ -96,22 +96,49 @@
    <item row="9" column="1">
     <widget class="QComboBox" name="languageComboBox"/>
    </item>
-   <item row="10" column="0">
-    <widget class="QCheckBox" name="systrayShowCheckBox">
-     <property name="text">
-      <string>Show a system tray icon</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0">
-    <widget class="QCheckBox" name="systrayMinimizeToTrayCheckBox">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Hide window to system tray when minimized</string>
-     </property>
-    </widget>
+   <item row="11" column="0" colspan="2">
+    <layout class="QGridLayout" name="systrayGridLayout">
+     <item row="0" column="0" colspan="3">
+      <widget class="QCheckBox" name="systrayShowCheckBox">
+       <property name="text">
+        <string>Show a system tray icon</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="systrayMinimizeToTrayCheckBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Hide window to system tray when minimized</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="systrayCloseToTrayCheckBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Hide window to system tray when closed</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
It seems that quite a lot of users disagree with your reasoning on issue #329. While the opinion is understandable, I thought that at least providing an option would be nice.

Also I made both "minimize [...]" and "close to tray" options easier to be visually recognized as dependent on "show a tray icon" by shifting them slightly to the right.