### PR TITLE
Add AutoType Inter-Character Delay

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -338,7 +338,7 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
     QString tmplName = tmpl.toLower();
     int num = -1;
     QList<AutoTypeAction*> list;
-
+	
     QRegExp repeatRegEx("(.+) (\\d+)", Qt::CaseSensitive, QRegExp::RegExp2);
     if (repeatRegEx.exactMatch(tmplName)) {
         tmplName = repeatRegEx.cap(1);
@@ -357,7 +357,7 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
             return list;
         }
     }
-
+	
     if (tmplName == "tab") {
         list.append(new AutoTypeKey(Qt::Key_Tab));
     }
@@ -495,6 +495,10 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
             }
             else {
                 list.append(new AutoTypeChar(ch));
+				if (config()->get("AutoTypeInterKeyDelay").toInt() > 0)
+				{
+					list.append(new AutoTypeDelay(config()->get("AutoTypeInterKeyDelay").toInt()));
+				}
             }
         }
     }

--- a/src/autotype/xcb/AutoTypeXCB.cpp
+++ b/src/autotype/xcb/AutoTypeXCB.cpp
@@ -808,6 +808,11 @@ void AutoTypePlatformX11::SendKeyPressedEvent(KeySym keysym)
 
     /* restore the old keyboard mask */
     SendModifier(&event, release_mask, KeyPress);
+	
+	timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 30 * 1000 * 1000;
+    nanosleep(&ts, nullptr);
 }
 
 int AutoTypePlatformX11::MyErrorHandler(Display* my_dpy, XErrorEvent* event)

--- a/src/autotype/xcb/AutoTypeXCB.cpp
+++ b/src/autotype/xcb/AutoTypeXCB.cpp
@@ -808,11 +808,6 @@ void AutoTypePlatformX11::SendKeyPressedEvent(KeySym keysym)
 
     /* restore the old keyboard mask */
     SendModifier(&event, release_mask, KeyPress);
-	
-	timespec ts;
-    ts.tv_sec = 0;
-    ts.tv_nsec = 30 * 1000 * 1000;
-    nanosleep(&ts, nullptr);
 }
 
 int AutoTypePlatformX11::MyErrorHandler(Display* my_dpy, XErrorEvent* event)

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -97,6 +97,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("MinimizeOnCopy", false);
     m_defaults.insert("UseGroupIconOnEntryCreation", false);
     m_defaults.insert("AutoTypeEntryTitleMatch", true);
+	m_defaults.insert("AutoTypeInterKeyDelay", 10);
     m_defaults.insert("security/clearclipboard", true);
     m_defaults.insert("security/clearclipboardtimeout", 10);
     m_defaults.insert("security/lockdatabaseidle", false);


### PR DESCRIPTION
There are many circumstances where an inter-character delay is needed.

Some Examples:
- When using bounce-keys for Accessibility, high-speed duplicate key-presses are rejected
- When entering password into websites with onclick JavaScript, problems are common

These problems are easily reproducible on Ubuntu 14.04 and 16.04 in Firefox on multiple website or by simply enabling Bounce Keys in the accessibility options.

This pull-request adds AutoTypeInterKeyDelay to the config system.

This change uses the existing Auto Type Delay system and should work across platforms but has only had basic testing performed on Ubuntu 16.04 by yours-truly.
