### PR TITLE
Fix build with newer Qt5

### DIFF
--- a/src/format/KeePass2XmlReader.cpp
+++ b/src/format/KeePass2XmlReader.cpp
@@ -388,7 +388,7 @@ void KeePass2XmlReader::parseBinaries()
             QString id = attr.value("ID").toString();
 
             QByteArray data;
-            if (attr.value("Compressed").compare("True", Qt::CaseInsensitive) == 0) {
+            if (attr.value("Compressed").compare(QLatin1String("True"), Qt::CaseInsensitive) == 0) {
                 data = readCompressedBinary();
             }
             else {


### PR DESCRIPTION
Here's the error message I used to have

```
FAILED: src/CMakeFiles/keepassx_core.dir/format/KeePass2XmlReader.cpp.o 
/usr/bin/clang++   -DKEEPASSX_BUILDING_CORE -DQT_CONCURRENT_LIB -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_EXCEPTIONS -DQT_NO_KEYWORDS -DQT_STRICT_ITERATORS -DQT_WIDGETS_LIB -I/home/apol/devel/frameworks/keepassx/src -Isrc -isystem /home/apol/devel/kde5/include -isystem /home/apol/devel/kde5/include/QtCore -isystem /home/apol/devel/kde5/lib64/mkspecs/linux-g++ -isystem /home/apol/devel/kde5/include/QtConcurrent -isystem /home/apol/devel/kde5/include/QtWidgets -isystem /home/apol/devel/kde5/include/QtGui -fno-common -fstack-protector --param=ssp-buffer-size=4 -Wall -Wextra -Wundef -Wpointer-arith -Wno-long-long -Wformat=2 -Wmissing-format-attribute -fvisibility=hidden -fvisibility-inlines-hidden -fno-exceptions -fno-rtti -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Werror=format-security -std=c++11 -g   -fPIC -std=gnu++11 -MD -MT src/CMakeFiles/keepassx_core.dir/format/KeePass2XmlReader.cpp.o -MF src/CMakeFiles/keepassx_core.dir/format/KeePass2XmlReader.cpp.o.d -o src/CMakeFiles/keepassx_core.dir/format/KeePass2XmlReader.cpp.o -c /home/apol/devel/frameworks/keepassx/src/format/KeePass2XmlReader.cpp
/home/apol/devel/frameworks/keepassx/src/format/KeePass2XmlReader.cpp:391:42: error: call to member function 'compare' is ambiguous
            if (attr.value("Compressed").compare("True", Qt::CaseInsensitive) == 0) {
                ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
/home/apol/devel/kde5/include/QtCore/qstring.h:1515:9: note: candidate function
    int compare(const QByteArray &s, Qt::CaseSensitivity cs = Qt::CaseSensitive) const
        ^
/home/apol/devel/kde5/include/QtCore/qstring.h:1584:24: note: candidate function
inline int QStringRef::compare(const QString &s, Qt::CaseSensitivity cs) const Q_DECL_NOTHROW
                       ^
/home/apol/devel/kde5/include/QtCore/qstring.h:1586:24: note: candidate function not viable: no known conversion from 'const char [5]' to 'const QStringRef' for 1st argument
inline int QStringRef::compare(const QStringRef &s, Qt::CaseSensitivity cs) const Q_DECL_NOTHROW
                       ^
/home/apol/devel/kde5/include/QtCore/qstring.h:1588:24: note: candidate function not viable: no known conversion from 'const char [5]' to 'QLatin1String' for 1st argument
inline int QStringRef::compare(QLatin1String s, Qt::CaseSensitivity cs) const Q_DECL_NOTHROW
                       ^
/home/apol/devel/kde5/include/QtCore/qstring.h:1590:24: note: candidate function not viable: no known conversion from 'const char [5]' to 'const QStringRef' for 1st argument
inline int QStringRef::compare(const QStringRef &s1, const QString &s2, Qt::CaseSensitivity cs) Q_DECL_NOTHROW
                       ^
/home/apol/devel/kde5/include/QtCore/qstring.h:1592:24: note: candidate function not viable: no known conversion from 'const char [5]' to 'const QStringRef' for 1st argument
inline int QStringRef::compare(const QStringRef &s1, const QStringRef &s2, Qt::CaseSensitivity cs) Q_DECL_NOTHROW
                       ^
/home/apol/devel/kde5/include/QtCore/qstring.h:1594:24: note: candidate function not viable: no known conversion from 'const char [5]' to 'const QStringRef' for 1st argument
inline int QStringRef::compare(const QStringRef &s1, QLatin1String s2, Qt::CaseSensitivity cs) Q_DECL_NOTHROW
                       ^
1 error generated.
```
