### PR TITLE
View entries as QR codes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,7 @@ set(keepassx_SOURCES
     gui/SortFilterHideProxyModel.cpp
     gui/UnlockDatabaseWidget.cpp
     gui/WelcomeWidget.cpp
+    gui/QRWidget.cpp
     gui/entry/AutoTypeAssociationsModel.cpp
     gui/entry/EditEntryWidget.cpp
     gui/entry/EditEntryWidget_p.h
@@ -145,12 +146,14 @@ set(keepassx_FORMS
     gui/SearchWidget.ui
     gui/SettingsWidgetGeneral.ui
     gui/SettingsWidgetSecurity.ui
+    gui/SettingsWidgetQR.ui
     gui/WelcomeWidget.ui
     gui/entry/EditEntryWidgetAdvanced.ui
     gui/entry/EditEntryWidgetAutoType.ui
     gui/entry/EditEntryWidgetHistory.ui
     gui/entry/EditEntryWidgetMain.ui
     gui/group/EditGroupWidgetMain.ui
+    gui/QRWidget.ui
 )
 
 if(MINGW)
@@ -161,11 +164,18 @@ endif()
 
 qt5_wrap_ui(keepassx_SOURCES ${keepassx_FORMS})
 
+#HACK: find qrencode
+find_library(qrencode qrencode)
+message(STATUS "qrencode: ${qrencode}")
+
 add_library(keepassx_core STATIC ${keepassx_SOURCES})
 set_target_properties(keepassx_core PROPERTIES COMPILE_DEFINITIONS KEEPASSX_BUILDING_CORE)
-target_link_libraries(keepassx_core Qt5::Core Qt5::Concurrent Qt5::Widgets)
+target_link_libraries(keepassx_core Qt5::Core Qt5::Concurrent Qt5::Widgets ${qrencode})
 
-add_executable(${PROGNAME} WIN32 MACOSX_BUNDLE ${keepassx_SOURCES_MAINEXE})
+
+add_executable(${PROGNAME} WIN32 MACOSX_BUNDLE ${keepassx_SOURCES_MAINEXE} )
+
+
 target_link_libraries(${PROGNAME}
                       keepassx_core
                       Qt5::Core

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -46,6 +46,7 @@
 #include "gui/entry/EntryView.h"
 #include "gui/group/EditGroupWidget.h"
 #include "gui/group/GroupView.h"
+#include "QRWidget.h"
 
 DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     : QStackedWidget(parent)
@@ -90,6 +91,11 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     m_searchWidget->hide();
     m_searchUi->caseSensitiveCheckBox->setVisible(false);
     m_searchUi->searchEdit->installEventFilter(this);
+    
+    //QR widget
+    m_QRWidget = new QRWidget(rightHandSideWidget);
+    addWidget(m_QRWidget);
+    
 
     QVBoxLayout* vLayout = new QVBoxLayout(rightHandSideWidget);
     vLayout->setMargin(0);
@@ -166,6 +172,9 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     connect(m_searchTimer, SIGNAL(timeout()), this, SLOT(search()));
     connect(closeAction, SIGNAL(triggered()), this, SLOT(closeSearch()));
 
+    //QR acknowledge
+    connect(m_QRWidget, &QRWidget::Finished, this, &DatabaseWidget::switchToView);
+    
     setCurrentWidget(m_mainWidget);
 }
 
@@ -1038,3 +1047,20 @@ bool DatabaseWidget::eventFilter(QObject* object, QEvent* event)
 
     return false;
 }
+
+
+void DatabaseWidget::viewQR()
+{
+  auto entry = m_entryView->currentEntry();
+  
+  m_QRWidget->setUser(entry->username());
+  m_QRWidget->setPass(entry->password());
+  
+  auto groupname = m_groupView->currentGroup()->name();
+  
+  m_QRWidget->setEntryName( QString("%1 > %2").arg(groupname, entry->title()) );
+  
+  setCurrentWidget(m_QRWidget);
+
+}
+

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -40,6 +40,7 @@ class QFile;
 class QMenu;
 class QSplitter;
 class UnlockDatabaseWidget;
+class QRWidget;
 
 namespace Ui {
     class SearchWidget;
@@ -128,6 +129,10 @@ public Q_SLOTS:
     void switchToOpenDatabase(const QString& fileName, const QString& password, const QString& keyFile);
     void switchToImportKeepass1(const QString& fileName);
     void openSearch();
+    
+    //view QR
+    void viewQR();
+    
 
 private Q_SLOTS:
     void entryActivationSignalReceived(Entry* entry, EntryModel::ModelColumn column);
@@ -175,6 +180,7 @@ private:
     Group* m_newParent;
     Group* m_lastGroup;
     QTimer* m_searchTimer;
+    QRWidget* m_QRWidget;
     QString m_filename;
     Uuid m_groupBeforeLock;
 };

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -213,6 +213,11 @@ MainWindow::MainWindow()
     m_actionMultiplexer.connect(m_ui->actionSearch, SIGNAL(triggered()),
                                 SLOT(openSearch()));
 
+    //QR view
+    //TODO: rename action appropriately
+    m_actionMultiplexer.connect(m_ui->actionViewQR, SIGNAL(triggered()), SLOT(viewQR()));
+//     connect(m_ui->actionViewQR, &QAction::triggered, m_ui->tabWidget->currentDatabaseWidget(), &DatabaseWidget::viewQR);
+    
     updateTrayIcon();
 }
 
@@ -314,6 +319,10 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             m_ui->actionDatabaseSave->setEnabled(true);
             m_ui->actionDatabaseSaveAs->setEnabled(true);
             m_ui->actionExportCsv->setEnabled(true);
+	    
+	    //QR code viewing action
+	    m_ui->actionViewQR->setEnabled(singleEntrySelected);
+	    
             break;
         }
         case DatabaseWidget::EditMode:

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -67,7 +67,7 @@ private Q_SLOTS:
     void toggleWindow();
     void lockDatabasesAfterInactivity();
     void repairDatabase();
-
+    
 private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);
 

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -30,7 +30,7 @@
     <item>
      <widget class="QStackedWidget" name="stackedWidget">
       <property name="currentIndex">
-       <number>2</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="pageDatabase">
        <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -97,16 +97,16 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>20</height>
+     <height>29</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
     <property name="title">
-     <string>Database</string>
+     <string>&amp;Database</string>
     </property>
     <widget class="QMenu" name="menuRecentDatabases">
      <property name="title">
-      <string>Recent databases</string>
+      <string>&amp;Recent databases</string>
      </property>
     </widget>
     <addaction name="actionDatabaseNew"/>
@@ -127,20 +127,20 @@
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
-     <string>Help</string>
+     <string>He&amp;lp</string>
     </property>
     <addaction name="actionAbout"/>
    </widget>
    <widget class="QMenu" name="menuEntries">
     <property name="title">
-     <string>Entries</string>
+     <string>E&amp;ntries</string>
     </property>
     <widget class="QMenu" name="menuEntryCopyAttribute">
      <property name="enabled">
       <bool>false</bool>
      </property>
      <property name="title">
-      <string>Copy attribute to clipboard</string>
+      <string>Copy att&amp;ribute to clipboard</string>
      </property>
      <addaction name="actionEntryCopyTitle"/>
      <addaction name="actionEntryCopyURL"/>
@@ -157,10 +157,11 @@
     <addaction name="actionEntryAutoType"/>
     <addaction name="actionEntryOpenUrl"/>
     <addaction name="actionSearch"/>
+    <addaction name="actionViewQR"/>
    </widget>
    <widget class="QMenu" name="menuGroups">
     <property name="title">
-     <string>Groups</string>
+     <string>&amp;Groups</string>
     </property>
     <addaction name="actionGroupNew"/>
     <addaction name="actionGroupEdit"/>
@@ -168,7 +169,7 @@
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
-     <string>Tools</string>
+     <string>&amp;Tools</string>
     </property>
     <addaction name="actionLockDatabases"/>
     <addaction name="actionSettings"/>
@@ -210,17 +211,17 @@
   </widget>
   <action name="actionQuit">
    <property name="text">
-    <string>Quit</string>
+    <string>&amp;Quit</string>
    </property>
   </action>
   <action name="actionAbout">
    <property name="text">
-    <string>About</string>
+    <string>&amp;About</string>
    </property>
   </action>
   <action name="actionDatabaseOpen">
    <property name="text">
-    <string>Open database</string>
+    <string>&amp;Open database</string>
    </property>
   </action>
   <action name="actionDatabaseSave">
@@ -228,7 +229,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Save database</string>
+    <string>&amp;Save database</string>
    </property>
   </action>
   <action name="actionDatabaseClose">
@@ -236,12 +237,12 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Close database</string>
+    <string>&amp;Close database</string>
    </property>
   </action>
   <action name="actionDatabaseNew">
    <property name="text">
-    <string>New database</string>
+    <string>&amp;New database</string>
    </property>
   </action>
   <action name="actionEntryNew">
@@ -249,7 +250,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Add new entry</string>
+    <string>&amp;Add new entry</string>
    </property>
   </action>
   <action name="actionEntryEdit">
@@ -257,7 +258,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>View/Edit entry</string>
+    <string>&amp;View/Edit entry</string>
    </property>
   </action>
   <action name="actionEntryDelete">
@@ -265,7 +266,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Delete entry</string>
+    <string>&amp;Delete entry</string>
    </property>
   </action>
   <action name="actionGroupNew">
@@ -273,7 +274,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Add new group</string>
+    <string>&amp;Add new group</string>
    </property>
   </action>
   <action name="actionGroupEdit">
@@ -281,7 +282,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Edit group</string>
+    <string>&amp;Edit group</string>
    </property>
   </action>
   <action name="actionGroupDelete">
@@ -289,7 +290,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Delete group</string>
+    <string>&amp;Delete group</string>
    </property>
   </action>
   <action name="actionDatabaseSaveAs">
@@ -297,7 +298,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Save database as</string>
+    <string>Sa&amp;ve database as</string>
    </property>
   </action>
   <action name="actionChangeMasterKey">
@@ -305,7 +306,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Change master key</string>
+    <string>Change &amp;master key</string>
    </property>
   </action>
   <action name="actionChangeDatabaseSettings">
@@ -313,7 +314,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Database settings</string>
+    <string>&amp;Database settings</string>
    </property>
    <property name="toolTip">
     <string>Database settings</string>
@@ -321,7 +322,7 @@
   </action>
   <action name="actionImportKeePass1">
    <property name="text">
-    <string>Import KeePass 1 database</string>
+    <string>&amp;Import KeePass 1 database</string>
    </property>
   </action>
   <action name="actionEntryClone">
@@ -329,7 +330,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Clone entry</string>
+    <string>&amp;Clone entry</string>
    </property>
   </action>
   <action name="actionSearch">
@@ -337,7 +338,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Find</string>
+    <string>&amp;Find</string>
    </property>
   </action>
   <action name="actionEntryCopyUsername">
@@ -345,7 +346,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Copy username</string>
+    <string>Copy &amp;username</string>
    </property>
    <property name="toolTip">
     <string>Copy username to clipboard</string>
@@ -356,7 +357,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Copy password</string>
+    <string>Cop&amp;y password</string>
    </property>
    <property name="toolTip">
     <string>Copy password to clipboard</string>
@@ -364,7 +365,7 @@
   </action>
   <action name="actionSettings">
    <property name="text">
-    <string>Settings</string>
+    <string>&amp;Settings</string>
    </property>
   </action>
   <action name="actionEntryAutoType">
@@ -372,7 +373,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Perform Auto-Type</string>
+    <string>&amp;Perform Auto-Type</string>
    </property>
   </action>
   <action name="actionEntryOpenUrl">
@@ -380,7 +381,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Open URL</string>
+    <string>&amp;Open URL</string>
    </property>
   </action>
   <action name="actionLockDatabases">
@@ -388,7 +389,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Lock databases</string>
+    <string>&amp;Lock databases</string>
    </property>
   </action>
   <action name="actionEntryCopyTitle">
@@ -396,7 +397,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Title</string>
+    <string>&amp;Title</string>
    </property>
   </action>
   <action name="actionEntryCopyURL">
@@ -404,7 +405,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>URL</string>
+    <string>&amp;URL</string>
    </property>
   </action>
   <action name="actionEntryCopyNotes">
@@ -412,7 +413,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Notes</string>
+    <string>&amp;Notes</string>
    </property>
   </action>
   <action name="actionExportCsv">
@@ -420,12 +421,20 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Export to CSV file</string>
+    <string>&amp;Export to CSV file</string>
    </property>
   </action>
   <action name="actionRepairDatabase">
    <property name="text">
-    <string>Repair database</string>
+    <string>Re&amp;pair database</string>
+   </property>
+  </action>
+  <action name="actionViewQR">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>View as QR codes</string>
    </property>
   </action>
  </widget>

--- a/src/gui/QRWidget.cpp
+++ b/src/gui/QRWidget.cpp
@@ -1,0 +1,255 @@
+#include "QRWidget.h"
+
+#include <QTimer>
+#include <qdebug.h>
+#include <QImage>
+#include <QPainter>
+
+#include <iostream>
+#include <iomanip>
+#include <type_traits>
+#include <QDialog>
+#include <cmath>
+
+#include "core/Config.h"
+
+QPixmap paintQRcode(const QRcode& code)
+{
+  QPixmap pmap(2*code.width+1,2*code.width+1);
+  QPainter painter(&pmap);
+  QBrush brush(Qt::black,Qt::SolidPattern);
+  QPen pen(brush,0);
+  painter.setPen(pen);
+  painter.setBrush(brush);
+  
+  pmap.fill(Qt::white);
+  
+  for(int i = 0; i < code.width; i++)
+    for(int j= 0; j < code.width; j++)
+    {
+      //extract data byte of image
+      int dat =  (*(code.data + i*code.width + j) & 0b1) ;
+      if(dat)
+	painter.drawRect(2*i,2*j,1,1);
+    }
+  
+  return pmap;
+}
+
+void printQRcode(const QRcode& code)
+{
+ for(int i =0 ; i  < code.width; i++)
+ {
+   for(int j = 0; j < code.width; j++)
+   {
+     bool dat = (*(code.data + i * code.width + j) & 1);
+     if(dat)
+       std::cout << "+" ;
+     else
+       std::cout << " ";
+       
+   }
+   std::cout << std::endl;
+ }
+  
+}
+
+
+
+QRWidget::QRWidget(QWidget* parent): QWidget(parent), m_ui( new Ui::QRWidget() ),
+m_blank(this), m_user_scene(this), m_pass_scene(this)
+{
+  
+  m_ui->setupUi(this);
+  
+  m_blank_pixmap.fill();
+  m_blank.addPixmap(m_blank_pixmap);
+  
+  m_user_scene.addItem(&m_user_pixmap_item);
+  m_pass_scene.addItem(&m_pass_pixmap_item);
+
+  m_ui->PassDisplay->setScene(&m_blank);
+  m_ui->UserDisplay->setScene(&m_blank);
+  
+  auto titleFont = m_ui->entryTitle->font();
+  titleFont.setBold(true);
+  titleFont.setPointSize(titleFont.pointSize() + 2);
+  m_ui->entryTitle->setFont(titleFont);
+  
+  
+  connect(m_ui->showPassButton, &QPushButton::pressed, this, &QRWidget::showPass);
+  connect(m_ui->showUserButton, &QPushButton::pressed, this, &QRWidget::showUser);
+  
+  connect(&m_pass_timer, &QTimer::timeout, this, &QRWidget::hidePass);
+  connect(&m_user_timer, &QTimer::timeout, this, &QRWidget::hideUser);
+ 
+  connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &QRWidget::accept);
+  connect(m_ui->buttonBox, &QDialogButtonBox::rejected,this,&QRWidget::cancel);
+  
+  
+  double timeout_sec = config()->get("QR/timeout").toDouble();
+  m_timer_msec = std::round(timeout_sec * 1000);
+  qDebug() << "m_timer_msec: "<< m_timer_msec;
+  
+  //NOTE: indices in the settings combobox chosen to correctly map onto QR_ECLEVEL enum
+  m_eclevel = static_cast<QRecLevel>(config()->get("QR/errorcorrection").toInt());
+  
+  startTimer(m_time_display_update_msec);
+  
+}
+
+void QRWidget::setPass(const QString& pass)
+{
+  m_pass_qr = get_qrcode(pass);
+  Q_ASSERT(m_pass_qr);
+  
+
+  //WARNING: may not work because pixmap is temporary
+  m_pass_pixmap = paintQRcode(*m_pass_qr);
+  m_pass_pixmap_item.setPixmap(m_pass_pixmap);
+  
+//   m_ui->PassDisplay->setScene(&m_pass_scene);
+  qDebug() << "bounding rect: " << m_pass_scene.itemsBoundingRect();
+}
+
+
+void QRWidget::setUser(const QString& user)
+{
+  m_user_qr = get_qrcode(user);
+  Q_ASSERT(m_user_qr);
+  
+  
+  m_user_pixmap = paintQRcode(*m_user_qr);
+  m_user_pixmap_item.setPixmap(m_user_pixmap);
+  
+//   m_ui->UserDisplay->setScene(&m_user_scene);
+}
+
+void QRWidget::setEntryName(const QString& title)
+{
+  
+  m_ui->entryTitle->setText(title);
+  
+
+}
+
+
+void QRWidget::scale_QRcodes()
+{
+  if(m_ui->UserDisplay->scene() == &m_user_scene)
+  {
+    m_ui->UserDisplay->fitInView(m_user_scene.itemsBoundingRect(), Qt::KeepAspectRatio);
+  }
+  if(m_ui->PassDisplay->scene() == &m_pass_scene)
+  {
+    m_ui->PassDisplay->fitInView(m_pass_scene.itemsBoundingRect(),Qt::KeepAspectRatio);
+  }
+}
+
+
+
+deleted_pointer< QRcode > QRWidget::get_qrcode(const QString& st)
+{
+  static const int qr_version = 0;
+  static const int casesens = 1;
+  
+  deleted_pointer<QRcode> qrptr(
+    QRcode_encodeString(st.toStdString().c_str(),qr_version, m_eclevel, QR_MODE_8, casesens),
+    QRdeleter  );
+
+  return qrptr;
+}
+
+
+void QRWidget::resizeEvent(QResizeEvent*)
+{
+    scale_QRcodes();
+}
+
+void QRWidget::showEvent(QShowEvent*)
+{
+    scale_QRcodes();
+}
+
+void QRWidget::timerEvent(QTimerEvent*)
+{
+  
+    double pass_remain_sec = m_pass_timer.remainingTime() / 1000.;
+    double user_remain_sec = m_user_timer.remainingTime() / 1000.;
+  
+    m_ui->PassTimeout->display(QString("%1").arg(pass_remain_sec,0,'f',1));
+    m_ui->UserTimeout->display(QString("%1").arg(user_remain_sec,0,'f',1));
+    
+}
+
+
+
+void QRWidget::showPass()
+{
+  if(m_ui->PassDisplay->scene() == &m_blank)
+  {
+    m_ui->PassDisplay->setScene(&m_pass_scene);
+    scale_QRcodes();
+    m_pass_timer.start(m_timer_msec);
+  }
+  
+}
+
+
+void QRWidget::showUser()
+{
+  if(m_ui->UserDisplay->scene() == &m_blank)
+  {
+    m_ui ->UserDisplay->setScene(&m_user_scene);
+    scale_QRcodes();
+    m_user_timer.start(m_timer_msec);
+  }
+  
+}
+
+void QRWidget::hidePass()
+{
+  if(m_ui->PassDisplay->scene() == &m_pass_scene)
+  {
+    m_ui->PassDisplay->setScene(&m_blank);
+  }
+
+  m_pass_timer.stop();
+  m_ui->PassTimeout->display(QString("%1").arg(m_timer_msec,0,'f',1));
+}
+
+
+void QRWidget::hideUser()
+{
+  if(m_ui->UserDisplay->scene() == &m_user_scene)
+  {
+    m_ui->UserDisplay->setScene(&m_blank);
+  }
+  
+  m_user_timer.stop();
+  m_ui->PassTimeout->display(QString("%1").arg(m_timer_msec,0,'f',1));
+  
+}
+
+
+void QRWidget::accept()
+{
+  clear();
+  Q_EMIT Finished(true);
+}
+
+
+void QRWidget::cancel()
+{
+  clear();
+  Q_EMIT Finished(false);
+}
+
+void QRWidget::clear()
+{
+  qDebug() << "TODO: implement clearing" ;
+
+}
+
+
+

--- a/src/gui/QRWidget.h
+++ b/src/gui/QRWidget.h
@@ -1,0 +1,98 @@
+#ifndef QR_WIDGET_H
+#define QR_WIDGET_H
+
+#include <memory>
+#include <functional>
+
+#include <QWidget>
+#include "ui_QRWidget.h"
+#include <qrencode.h>
+#include <QGraphicsScene>
+#include <QImage>
+#include <QGraphicsPixmapItem>
+#include <QPixmap>
+#include <QTimer>
+#include <map>
+
+class QTimer;
+class QImage;
+class QResizeEvent;
+
+
+template <typename T>
+using deleted_pointer = std::unique_ptr<T,std::function<void(T*)>>;
+
+auto QRdeleter = [](QRcode* code){QRcode_free(code);};
+
+
+QPixmap paintQRcode(const QRcode& code);
+
+
+
+
+
+class QRWidget : public QWidget
+{
+  Q_OBJECT
+  
+public:
+ QRWidget(QWidget* parent = nullptr);
+ 
+public Q_SLOTS:
+ void setUser(const QString& user);
+ void setPass(const QString& pass);
+ 
+ void setEntryName(const QString& title);
+ 
+ void showUser();
+ void showPass();
+ 
+ void hideUser();
+ void hidePass();
+ 
+ void cancel();
+ void accept();
+ 
+ void clear();
+
+Q_SIGNALS:
+  void Finished(bool accepted);
+  
+ 
+ private:
+   
+  deleted_pointer<QRcode> get_qrcode(const QString& st);
+  
+  void scale_QRcodes();
+  
+  virtual void resizeEvent(QResizeEvent*);
+  virtual void showEvent(QShowEvent*);
+  virtual void timerEvent(QTimerEvent*);
+   
+  const std::unique_ptr<Ui::QRWidget> m_ui;
+  
+  deleted_pointer<QRcode> m_user_qr;
+  deleted_pointer<QRcode> m_pass_qr;
+  
+  QRecLevel m_eclevel;
+  
+  int m_timer_msec;
+  const int m_time_display_update_msec = 10;
+  
+  QGraphicsScene m_blank;
+  QGraphicsScene m_user_scene;
+  QGraphicsScene m_pass_scene;
+  
+  QTimer m_user_timer; 
+  QTimer m_pass_timer;
+  
+  QGraphicsPixmapItem m_user_pixmap_item;
+  QGraphicsPixmapItem m_pass_pixmap_item;
+  
+  QPixmap m_user_pixmap;
+  QPixmap m_pass_pixmap;
+  QPixmap m_blank_pixmap;
+  
+};
+
+#endif

--- a/src/gui/QRWidget.ui
+++ b/src/gui/QRWidget.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QRWidget</class>
+ <widget class="QWidget" name="QRWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>576</width>
+    <height>442</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="entryTitle">
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>1</width>
+       <height>3</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QGraphicsView" name="UserDisplay"/>
+     </item>
+     <item>
+      <widget class="QGraphicsView" name="PassDisplay"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="showUserButton">
+       <property name="text">
+        <string>show username</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLCDNumber" name="UserTimeout">
+       <property name="digitCount">
+        <number>3</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="showPassButton">
+       <property name="text">
+        <string>show password</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLCDNumber" name="PassTimeout">
+       <property name="digitCount">
+        <number>3</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -18,6 +18,7 @@
 #include "SettingsWidget.h"
 #include "ui_SettingsWidgetGeneral.h"
 #include "ui_SettingsWidgetSecurity.h"
+#include "ui_SettingsWidgetQR.h"
 
 #include "autotype/AutoType.h"
 #include "core/Config.h"
@@ -27,8 +28,10 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     : EditWidget(parent)
     , m_secWidget(new QWidget())
     , m_generalWidget(new QWidget())
+    , m_QRWidget(new QWidget())
     , m_secUi(new Ui::SettingsWidgetSecurity())
     , m_generalUi(new Ui::SettingsWidgetGeneral())
+    , m_QRUi(new Ui::SettingsWidgetQR())
     , m_globalAutoTypeKey(static_cast<Qt::Key>(0))
     , m_globalAutoTypeModifiers(Qt::NoModifier)
 {
@@ -36,8 +39,10 @@ SettingsWidget::SettingsWidget(QWidget* parent)
 
     m_secUi->setupUi(m_secWidget);
     m_generalUi->setupUi(m_generalWidget);
+    m_QRUi->setupUi(m_QRWidget);
     add(tr("General"), m_generalWidget);
     add(tr("Security"), m_secWidget);
+    add(tr("QR"),m_QRWidget);
 
     m_generalUi->autoTypeShortcutWidget->setVisible(autoType()->isAvailable());
     m_generalUi->autoTypeShortcutLabel->setVisible(autoType()->isAvailable());
@@ -108,6 +113,10 @@ void SettingsWidget::loadSettings()
 
     m_secUi->autoTypeAskCheckBox->setChecked(config()->get("security/autotypeask").toBool());
 
+    //QR settings
+    m_QRUi->timeoutSpinBox->setValue(config()->get("QR/timeout").toDouble());
+    m_QRUi->errorCorrectionComboBox->setCurrentIndex(config()->get("QR/errorcorrection").toInt());
+    
     setCurrentRow(0);
 }
 
@@ -146,6 +155,9 @@ void SettingsWidget::saveSettings()
 
     config()->set("security/autotypeask", m_secUi->autoTypeAskCheckBox->isChecked());
 
+    config()->set("QR/timeout", m_QRUi->timeoutSpinBox->value());
+    config()->set("QR/errorcorrection", m_QRUi->errorCorrectionComboBox->currentIndex());
+    
     Q_EMIT editFinished(true);
 }
 

--- a/src/gui/SettingsWidget.h
+++ b/src/gui/SettingsWidget.h
@@ -23,6 +23,7 @@
 namespace Ui {
     class SettingsWidgetGeneral;
     class SettingsWidgetSecurity;
+    class SettingsWidgetQR;
 }
 
 class SettingsWidget : public EditWidget
@@ -45,8 +46,11 @@ private Q_SLOTS:
 private:
     QWidget* const m_secWidget;
     QWidget* const m_generalWidget;
+    QWidget* const m_QRWidget;
     const QScopedPointer<Ui::SettingsWidgetSecurity> m_secUi;
     const QScopedPointer<Ui::SettingsWidgetGeneral> m_generalUi;
+    const QScopedPointer<Ui::SettingsWidgetQR> m_QRUi;
+    
     Qt::Key m_globalAutoTypeKey;
     Qt::KeyboardModifiers m_globalAutoTypeModifiers;
 };

--- a/src/qrdev.cpp
+++ b/src/qrdev.cpp
@@ -1,0 +1,31 @@
+
+#include <QApplication>
+#include "gui/QRWidget.h"
+#include <string>
+
+#include <iostream>
+
+int main(int argc, char** argv)
+{
+  QApplication app(argc,argv);
+  
+  std::string testUser = "sdsuhdfasdfkljadlkbermnb";
+  std::string testPass = "Oscar Wilde";
+    
+  QRWidget* widget = new QRWidget();
+  
+  app.setActiveWindow(static_cast<QWidget*>(widget));
+//   test QR generation
+  
+  widget->setUser(testUser);
+  widget->setPass(testPass);
+  
+  widget->show();
+  
+  
+  
+  return app.exec();
+
+
+
+}


### PR DESCRIPTION
Add a feature which allows an entry's username and password to be viewed as
QR codes. The QR codes are hidden until a button is clicked, which reveals
them for a limited time, the timeout being settable in the settings dialog.

This is useful for being able to quickly enter long and secure passwords
into mobile devices.