### PR TITLE
Enable context-menu-option "Add new Entry" during search.

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -149,6 +149,7 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
             SLOT(entryActivationSignalReceived(Entry*, EntryModel::ModelColumn)));
     connect(m_entryView, SIGNAL(entrySelectionChanged()), SIGNAL(entrySelectionChanged()));
     connect(m_editEntryWidget, SIGNAL(editFinished(bool)), SLOT(switchToView(bool)));
+    connect(m_editEntryWidget, SIGNAL(editFinished(bool)), SLOT(startSearch()));
     connect(m_editEntryWidget, SIGNAL(historyEntryActivated(Entry*)), SLOT(switchToHistoryView(Entry*)));
     connect(m_historyEditEntryWidget, SIGNAL(editFinished(bool)), SLOT(switchBackToEntryEdit()));
     connect(m_editGroupWidget, SIGNAL(editFinished(bool)), SLOT(switchToView(bool)));
@@ -258,7 +259,7 @@ Database* DatabaseWidget::database()
 
 void DatabaseWidget::createEntry()
 {
-    if (!m_groupView->currentGroup()) {
+    if (!m_groupView->currentGroup() && !isInSearchMode()) {
         Q_ASSERT(false);
         return;
     }
@@ -266,7 +267,11 @@ void DatabaseWidget::createEntry()
     m_newEntry = new Entry();
     m_newEntry->setUuid(Uuid::random());
     m_newEntry->setUsername(m_db->metadata()->defaultUserName());
-    m_newParent = m_groupView->currentGroup();
+    if (isInSearchMode()) {
+        m_newParent = m_db->rootGroup();
+    } else {
+        m_newParent = m_groupView->currentGroup();
+    }
     setIconFromParent();
     switchToEntryEdit(m_newEntry, true);
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -292,7 +292,7 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             bool entriesSelected = dbWidget->numberOfSelectedEntries() > 0;
             bool groupSelected = dbWidget->isGroupSelected();
 
-            m_ui->actionEntryNew->setEnabled(!inSearch);
+            m_ui->actionEntryNew->setEnabled(true);
             m_ui->actionEntryClone->setEnabled(singleEntrySelected && !inSearch);
             m_ui->actionEntryEdit->setEnabled(singleEntrySelected);
             m_ui->actionEntryDelete->setEnabled(entriesSelected);


### PR DESCRIPTION
The entry is created in the root-group since there is no group-selection during search.