### PR TITLE
Add sortable last-modified column to entry list view

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -220,6 +220,15 @@ QString Entry::notes() const
     return m_attributes->value(EntryAttributes::NotesKey);
 }
 
+QString Entry::lastModified() const
+{
+	// Surely there's a way to ask for sort-by-object and convert to string
+	// later, by giving this item a non-string model. But I'm going to do
+	// a simpler thing for now, to avoid having to learn Qt.
+	QString timeFormat("yyyy-MM-dd HH:mm:ss");
+	return m_data.timeInfo.lastModificationTime().toLocalTime().toString(timeFormat);
+}
+
 bool Entry::isExpired() const
 {
     return m_data.timeInfo.expires() && m_data.timeInfo.expiryTime() < QDateTime::currentDateTimeUtc();

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -77,6 +77,7 @@ public:
     QString username() const;
     QString password() const;
     QString notes() const;
+    QString lastModified() const;
     bool isExpired() const;
     EntryAttributes* attributes();
     const EntryAttributes* attributes() const;

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -117,7 +117,7 @@ int EntryModel::columnCount(const QModelIndex& parent) const
 {
     Q_UNUSED(parent);
 
-    return 4;
+    return 5;
 }
 
 QVariant EntryModel::data(const QModelIndex& index, int role) const
@@ -141,6 +141,8 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             return entry->username();
         case Url:
             return entry->url();
+        case LastModified:
+            return entry->lastModified();
         }
     }
     else if (role == Qt::DecorationRole) {
@@ -181,6 +183,8 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
             return tr("Username");
         case Url:
             return tr("URL");
+        case LastModified:
+            return tr("Last Modified");
         }
     }
 

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -33,7 +33,8 @@ public:
         ParentGroup = 0,
         Title = 1,
         Username = 2,
-        Url = 3
+        Url = 3,
+        LastModified = 4
     };
 
     explicit EntryModel(QObject* parent = nullptr);


### PR DESCRIPTION
Prior versions of keepassx had the ability to sort entries by last-modified time. I synchronize my keepass db to multiple devices with svn; this feature is invaluable for handling accidental conflicts. This patch reintroduces the last-modified column.