### PR TITLE
Lock database when OS is locked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
   - osx
+osx_image: xcode8.2
 compiler:
   - gcc
   - clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,9 @@ find_package(Qt5Test          5.2 REQUIRED)
 find_package(Qt5LinguistTools 5.2 REQUIRED)
 set(CMAKE_AUTOMOC ON)
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    find_package(Qt5DBus       5.2 REQUIRED)
+endif()
 # Debian sets the the build type to None for package builds.
 # Make sure we don't enable asserts there.
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS_NONE QT_NO_DEBUG)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,6 +138,14 @@ if(APPLE)
         )
 endif()
 
+if(MINGW)
+    set(keepassx_SOURCES
+        ${keepassx_SOURCES}
+        core/ScreenLockListenerWin.h
+        core/ScreenLockListenerWin.cpp
+        )
+endif()
+
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     set(keepassx_SOURCES
         ${keepassx_SOURCES}
@@ -188,6 +196,10 @@ endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     target_link_libraries(keepassx_core Qt5::DBus)
+endif()
+
+if(MINGW)
+    target_link_libraries(keepassx_core Wtsapi32.lib)
 endif()
 
 add_executable(${PROGNAME} WIN32 MACOSX_BUNDLE ${keepassx_SOURCES_MAINEXE})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,8 @@ set(keepassx_SOURCES
     core/ListDeleter.h
     core/Metadata.cpp
     core/PasswordGenerator.cpp
+    core/ScreenLockListener.cpp
+    core/ScreenLockListener.h
     core/SignalMultiplexer.cpp
     core/TimeDelta.cpp
     core/TimeInfo.cpp
@@ -128,6 +130,14 @@ set(keepassx_SOURCES
     streams/SymmetricCipherStream.cpp
 )
 
+if(APPLE)
+    set(keepassx_SOURCES
+        ${keepassx_SOURCES}
+        core/ScreenLockListenerMac.h
+        core/ScreenLockListenerMac.cpp
+        )
+endif()
+
 set(keepassx_SOURCES_MAINEXE
     main.cpp
 )
@@ -164,6 +174,9 @@ qt5_wrap_ui(keepassx_SOURCES ${keepassx_FORMS})
 add_library(keepassx_core STATIC ${keepassx_SOURCES})
 set_target_properties(keepassx_core PROPERTIES COMPILE_DEFINITIONS KEEPASSX_BUILDING_CORE)
 target_link_libraries(keepassx_core Qt5::Core Qt5::Concurrent Qt5::Widgets)
+if(APPLE)
+    target_link_libraries(keepassx_core "-framework Foundation")
+endif()
 
 add_executable(${PROGNAME} WIN32 MACOSX_BUNDLE ${keepassx_SOURCES_MAINEXE})
 target_link_libraries(${PROGNAME}
@@ -189,6 +202,7 @@ install(TARGETS ${PROGNAME}
 add_subdirectory(autotype)
 
 if(APPLE)
+
   if(QT_MAC_USE_COCOA AND EXISTS "${QT_LIBRARY_DIR}/Resources/qt_menu.nib")
     install(DIRECTORY "${QT_LIBRARY_DIR}/Resources/qt_menu.nib"
             DESTINATION "${DATA_INSTALL_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,6 +138,14 @@ if(APPLE)
         )
 endif()
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    set(keepassx_SOURCES
+        ${keepassx_SOURCES}
+        core/ScreenLockListenerDBus.h
+        core/ScreenLockListenerDBus.cpp
+        )
+endif()
+
 set(keepassx_SOURCES_MAINEXE
     main.cpp
 )
@@ -178,6 +186,10 @@ if(APPLE)
     target_link_libraries(keepassx_core "-framework Foundation")
 endif()
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    target_link_libraries(keepassx_core Qt5::DBus)
+endif()
+
 add_executable(${PROGNAME} WIN32 MACOSX_BUNDLE ${keepassx_SOURCES_MAINEXE})
 target_link_libraries(${PROGNAME}
                       keepassx_core
@@ -186,6 +198,10 @@ target_link_libraries(${PROGNAME}
                       Qt5::Widgets
                       ${GCRYPT_LIBRARIES}
                       ${ZLIB_LIBRARIES})
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  target_link_libraries(${PROGNAME} Qt5::DBus)
+endif()
 
 set_target_properties(${PROGNAME} PROPERTIES ENABLE_EXPORTS ON)
 

--- a/src/core/ScreenLockListener.cpp
+++ b/src/core/ScreenLockListener.cpp
@@ -6,8 +6,11 @@
 #if defined(Q_OS_LINUX)
 #include "ScreenLockListenerDBus.h"
 #endif
+#if defined(Q_OS_WIN)
+#include "ScreenLockListenerWin.h"
+#endif
 
-ScreenLockListener::ScreenLockListener(QObject* parent):
+ScreenLockListener::ScreenLockListener(QWidget* parent):
     QObject(parent){
 #if defined(Q_OS_OSX)
     m_mac_listener= ScreenLockListenerMac::instance();
@@ -16,6 +19,10 @@ ScreenLockListener::ScreenLockListener(QObject* parent):
 #if defined(Q_OS_LINUX)
     m_dbus_listener= new ScreenLockListenerDBus(this);
     connect(m_dbus_listener,SIGNAL(screenLocked()), this,SIGNAL(screenLocked()));
+#endif
+#if defined(Q_OS_WIN)
+    m_win_listener= new ScreenLockListenerWin(parent);
+    connect(m_win_listener,SIGNAL(screenLocked()), this,SIGNAL(screenLocked()));
 #endif
 }
 

--- a/src/core/ScreenLockListener.cpp
+++ b/src/core/ScreenLockListener.cpp
@@ -1,0 +1,20 @@
+#include "ScreenLockListener.h"
+
+#if defined(Q_OS_OSX)
+#include "ScreenLockListenerMac.h"
+#endif
+
+ScreenLockListener::ScreenLockListener(QObject* parent):
+    QObject(parent){
+#if defined(Q_OS_OSX)
+    m_mac_listener= ScreenLockListenerMac::instance();
+    connect(m_mac_listener,SIGNAL(screenLocked()), this,SIGNAL(screenLocked()));
+#endif
+}
+
+ScreenLockListener::~ScreenLockListener(){
+}
+
+void ScreenLockListener::onNotification() {
+    Q_EMIT screenLocked();
+}

--- a/src/core/ScreenLockListener.cpp
+++ b/src/core/ScreenLockListener.cpp
@@ -3,12 +3,19 @@
 #if defined(Q_OS_OSX)
 #include "ScreenLockListenerMac.h"
 #endif
+#if defined(Q_OS_LINUX)
+#include "ScreenLockListenerDBus.h"
+#endif
 
 ScreenLockListener::ScreenLockListener(QObject* parent):
     QObject(parent){
 #if defined(Q_OS_OSX)
     m_mac_listener= ScreenLockListenerMac::instance();
     connect(m_mac_listener,SIGNAL(screenLocked()), this,SIGNAL(screenLocked()));
+#endif
+#if defined(Q_OS_LINUX)
+    m_dbus_listener= new ScreenLockListenerDBus(this);
+    connect(m_dbus_listener,SIGNAL(screenLocked()), this,SIGNAL(screenLocked()));
 #endif
 }
 

--- a/src/core/ScreenLockListener.h
+++ b/src/core/ScreenLockListener.h
@@ -1,0 +1,26 @@
+#ifndef SCREENLOCKLISTENER_H
+#define SCREENLOCKLISTENER_H
+
+#include <QObject>
+
+#if defined(Q_OS_OSX)
+class ScreenLockListenerMac;
+#endif
+class ScreenLockListener : public QObject {
+    Q_OBJECT
+
+public:
+    ScreenLockListener(QObject* parent=NULL);
+    ~ScreenLockListener();
+    void onNotification();
+
+Q_SIGNALS:
+    void screenLocked();
+
+private:
+#if defined(Q_OS_OSX)
+    ScreenLockListenerMac* m_mac_listener;
+#endif
+};
+
+#endif // SCREENLOCKLISTENER_H

--- a/src/core/ScreenLockListener.h
+++ b/src/core/ScreenLockListener.h
@@ -6,6 +6,9 @@
 #if defined(Q_OS_OSX)
 class ScreenLockListenerMac;
 #endif
+#if defined(Q_OS_LINUX)
+class ScreenLockListenerDBus;
+#endif
 class ScreenLockListener : public QObject {
     Q_OBJECT
 
@@ -20,6 +23,9 @@ Q_SIGNALS:
 private:
 #if defined(Q_OS_OSX)
     ScreenLockListenerMac* m_mac_listener;
+#endif
+#if defined(Q_OS_LINUX)
+    ScreenLockListenerDBus* m_dbus_listener;
 #endif
 };
 

--- a/src/core/ScreenLockListener.h
+++ b/src/core/ScreenLockListener.h
@@ -1,7 +1,7 @@
 #ifndef SCREENLOCKLISTENER_H
 #define SCREENLOCKLISTENER_H
 
-#include <QObject>
+#include <QWidget>
 
 #if defined(Q_OS_OSX)
 class ScreenLockListenerMac;
@@ -9,11 +9,14 @@ class ScreenLockListenerMac;
 #if defined(Q_OS_LINUX)
 class ScreenLockListenerDBus;
 #endif
+#if defined(Q_OS_WIN)
+class ScreenLockListenerWin;
+#endif
 class ScreenLockListener : public QObject {
     Q_OBJECT
 
 public:
-    ScreenLockListener(QObject* parent=NULL);
+    ScreenLockListener(QWidget* parent=NULL);
     ~ScreenLockListener();
     void onNotification();
 
@@ -26,6 +29,9 @@ private:
 #endif
 #if defined(Q_OS_LINUX)
     ScreenLockListenerDBus* m_dbus_listener;
+#endif
+#if defined(Q_OS_WIN)
+    ScreenLockListenerWin* m_win_listener;
 #endif
 };
 

--- a/src/core/ScreenLockListenerDBus.cpp
+++ b/src/core/ScreenLockListenerDBus.cpp
@@ -1,0 +1,74 @@
+#include <QCoreApplication>
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusReply>
+#include "ScreenLockListenerDBus.h"
+#include <iostream>
+
+ScreenLockListenerDBus::ScreenLockListenerDBus(QObject *parent) : QObject(parent)
+{
+    QDBusConnection sessionBus = QDBusConnection::sessionBus();
+    QDBusConnection systemBus = QDBusConnection::systemBus();
+    std::cout << "connect org.gnome.SessionManager.Presence.StatusChanged " << std::endl;
+    sessionBus.connect(
+                "org.gnome.SessionManager", // service
+                "/org/gnome/SessionManager/Presence", // path
+                "org.gnome.SessionManager.Presence", // interface
+                "StatusChanged", // signal name
+                this, //receiver
+                SLOT(gnomeSessionStatusChanged(uint)));
+
+    std::cout << "connect org.freedesktop.login1.Manager.PrepareForSleep " << std::endl;
+    systemBus.connect(
+                "org.freedesktop.login1", // service
+                "/org/freedesktop/login1", // path
+                "org.freedesktop.login1.Manager", // interface
+                "PrepareForSleep", // signal name
+                this, //receiver
+                SLOT(logindPrepareForSleep(bool)));
+
+    std::cout << "connect com.canonical.Unity.Session.Locked " << std::endl;
+    sessionBus.connect(
+                "com.canonical.Unity", // service
+                "/com/canonical/Unity/Session", // path
+                "com.canonical.Unity.Session", // interface
+                "Locked", // signal name
+                this, //receiver
+                SLOT(unityLocked()));
+
+    /* Currently unable to get the current user session from login1.Manager
+    QDBusInterface login1_manager_iface("org.freedesktop.login1", "/org/freedesktop/login1",
+                              "org.freedesktop.login1.Manager", systemBus);
+    if(login1_manager_iface.isValid()){
+        qint64 my_pid = QCoreApplication::applicationPid();
+        QDBusReply<QString> reply = login1_manager_iface.call("GetSessionByPID",static_cast<quint32>(my_pid));
+        if (reply.isValid()){
+            QString current_session = reply.value();
+            std::cout << "current session is " << current_session.toStdString() << std::endl;
+        } else {
+            std::cout << reply.error().message().toStdString() << std::endl;
+        }
+    } else {
+        std::cout << login1_manager_iface.lastError().message().toStdString() << std::endl;
+    }
+    */
+}
+
+void ScreenLockListenerDBus::gnomeSessionStatusChanged(uint status){
+    std::cout << "org.gnome.SessionManager.Presence.StatusChanged " << status << std::endl;
+    if(status != 0){
+        Q_EMIT screenLocked();
+    }
+}
+
+void ScreenLockListenerDBus::logindPrepareForSleep(bool beforeSleep){
+    std::cout << "org.freedesktop.login1.Manager.PrepareForSleep " << beforeSleep << std::endl;
+    if(beforeSleep){
+        Q_EMIT screenLocked();
+    }
+}
+
+void ScreenLockListenerDBus::unityLocked(){
+    std::cout << "com.canonical.Unity.Session.Locked " << std::endl;
+    Q_EMIT screenLocked();
+}

--- a/src/core/ScreenLockListenerDBus.h
+++ b/src/core/ScreenLockListenerDBus.h
@@ -1,0 +1,21 @@
+#ifndef SCREENLOCKLISTENERDBUS_H
+#define SCREENLOCKLISTENERDBUS_H
+
+#include <QObject>
+
+class ScreenLockListenerDBus : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ScreenLockListenerDBus(QObject *parent = 0);
+
+Q_SIGNALS:
+    void screenLocked();
+
+private Q_SLOTS:
+    void gnomeSessionStatusChanged(uint status);
+    void logindPrepareForSleep(bool beforeSleep);
+    void unityLocked();
+};
+
+#endif // SCREENLOCKLISTENERDBUS_H

--- a/src/core/ScreenLockListenerMac.cpp
+++ b/src/core/ScreenLockListenerMac.cpp
@@ -1,0 +1,39 @@
+#include <QMutexLocker>
+#include <CoreFoundation/CoreFoundation.h>
+#include "ScreenLockListenerMac.h"
+
+ScreenLockListenerMac* ScreenLockListenerMac::instance(){
+    static QMutex mutex;
+    QMutexLocker lock(&mutex);
+
+    static ScreenLockListenerMac* m_ptr=NULL;
+    if (m_ptr==NULL){
+        m_ptr = new ScreenLockListenerMac();
+    }
+    return m_ptr;
+}
+
+void ScreenLockListenerMac::notificationCenterCallBack(CFNotificationCenterRef /*center*/, void */*observer*/,
+                                        CFNotificationName /*name*/, const void */*object*/, CFDictionaryRef /*userInfo*/){
+    instance()->onSignalReception();
+}
+
+ScreenLockListenerMac::ScreenLockListenerMac(QObject* parent):
+    QObject(parent){
+    CFNotificationCenterRef distCenter;
+    CFStringRef screenIsLockedSignal = CFSTR("com.apple.screenIsLocked");
+    distCenter = CFNotificationCenterGetDistributedCenter();
+    if (NULL == distCenter)
+        return;
+
+    CFNotificationCenterAddObserver(
+                distCenter,
+                this, &ScreenLockListenerMac::notificationCenterCallBack,
+                screenIsLockedSignal,
+                NULL,
+                CFNotificationSuspensionBehaviorDeliverImmediately);
+}
+
+void ScreenLockListenerMac::onSignalReception(){
+    Q_EMIT screenLocked();
+}

--- a/src/core/ScreenLockListenerMac.h
+++ b/src/core/ScreenLockListenerMac.h
@@ -1,0 +1,28 @@
+#ifndef SCREENLOCKLISTENERMAC_H
+#define SCREENLOCKLISTENERMAC_H
+#include <QObject>
+
+#if defined(Q_OS_OSX)
+#include <CoreFoundation/CoreFoundation.h>
+#endif //Q_OS_OSX
+
+class ScreenLockListenerMac: public QObject {
+    Q_OBJECT
+
+public:
+    static ScreenLockListenerMac* instance();
+
+#if defined(Q_OS_OSX)
+    static void notificationCenterCallBack(CFNotificationCenterRef /*center*/, void */*observer*/,
+                            CFNotificationName /*name*/, const void */*object*/, CFDictionaryRef /*userInfo*/);
+#endif //Q_OS_OSX
+
+Q_SIGNALS:
+    void screenLocked();
+
+private:
+    ScreenLockListenerMac(QObject* parent=NULL);
+    void onSignalReception();
+
+};
+#endif //SCREENLOCKLISTENERMAC_H

--- a/src/core/ScreenLockListenerWin.cpp
+++ b/src/core/ScreenLockListenerWin.cpp
@@ -1,0 +1,70 @@
+#include <QApplication>
+#include "ScreenLockListenerWin.h"
+
+#include <windows.h>
+#include <wtsapi32.h>
+
+/*
+ * See https://msdn.microsoft.com/en-us/library/windows/desktop/aa373196(v=vs.85).aspx
+ * See https://msdn.microsoft.com/en-us/library/aa383841(v=vs.85).aspx
+ * See https://blogs.msdn.microsoft.com/oldnewthing/20060104-50/?p=32783
+ */
+ScreenLockListenerWin::ScreenLockListenerWin(QWidget *parent) :
+    QObject(parent),
+    QAbstractNativeEventFilter()
+{
+    Q_ASSERT(parent!=NULL);
+    // On windows, we need to register for platform specific messages and
+    // install a message handler for them
+    QCoreApplication::instance()->installNativeEventFilter(this);
+
+    // This call requests a notification from windows when a laptop is closed
+    HPOWERNOTIFY hPnotify = RegisterPowerSettingNotification(
+                reinterpret_cast<HWND>(parent->winId()),
+                &GUID_LIDSWITCH_STATE_CHANGE, DEVICE_NOTIFY_WINDOW_HANDLE);
+    m_powernotificationhandle = reinterpret_cast<void*>(hPnotify);
+
+    // This call requests a notification for session changes
+    if (!WTSRegisterSessionNotification(
+                reinterpret_cast<HWND>(parent->winId()),
+                NOTIFY_FOR_THIS_SESSION)){
+    }
+}
+
+ScreenLockListenerWin::~ScreenLockListenerWin()
+{
+    HWND h= reinterpret_cast<HWND>(static_cast<QWidget*>(parent())->winId());
+    WTSUnRegisterSessionNotification(h);
+
+    if(m_powernotificationhandle){
+        UnregisterPowerSettingNotification(reinterpret_cast<HPOWERNOTIFY>(m_powernotificationhandle));
+    }
+}
+
+bool ScreenLockListenerWin::nativeEventFilter(const QByteArray &eventType, void *message, long *)
+{
+    if(eventType == "windows_generic_MSG" || eventType == "windows_dispatcher_MSG"){
+        MSG* m = static_cast<MSG *>(message);
+        if(m->message == WM_POWERBROADCAST){
+            const POWERBROADCAST_SETTING* setting = reinterpret_cast<const POWERBROADCAST_SETTING*>(m->lParam);
+            if (setting->PowerSetting == GUID_LIDSWITCH_STATE_CHANGE){
+                const DWORD* state = reinterpret_cast<const DWORD*>(&setting->Data);
+                if (*state == 0){
+                    Q_EMIT screenLocked();
+                    return true;
+                }
+            }
+        }
+        if(m->message == WM_WTSSESSION_CHANGE){
+            if (m->wParam==WTS_CONSOLE_DISCONNECT){
+                Q_EMIT screenLocked();
+                return true;
+            }
+            if (m->wParam==WTS_SESSION_LOCK){
+                Q_EMIT screenLocked();
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/src/core/ScreenLockListenerWin.h
+++ b/src/core/ScreenLockListenerWin.h
@@ -1,0 +1,22 @@
+#ifndef SCREENLOCKLISTENERWIN_H
+#define SCREENLOCKLISTENERWIN_H
+
+#include <QWidget>
+#include <QAbstractNativeEventFilter>
+
+class ScreenLockListenerWin : public QObject, public QAbstractNativeEventFilter
+{
+    Q_OBJECT
+public:
+    explicit ScreenLockListenerWin(QWidget *parent = 0);
+    ~ScreenLockListenerWin();
+    virtual bool nativeEventFilter(const QByteArray &eventType, void *message, long *) Q_DECL_OVERRIDE;
+
+Q_SIGNALS:
+    void screenLocked();
+
+private:
+    void * m_powernotificationhandle;
+};
+
+#endif // SCREENLOCKLISTENERWIN_H

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -213,7 +213,16 @@ MainWindow::MainWindow()
     m_actionMultiplexer.connect(m_ui->actionSearch, SIGNAL(triggered()),
                                 SLOT(openSearch()));
 
+    m_screenLockListener = new ScreenLockListener(this);
+    connect(m_screenLockListener, SIGNAL(screenLocked()), SLOT(handleScreenLock()));
     updateTrayIcon();
+}
+
+void MainWindow::handleScreenLock()
+{
+    if (config()->get("AutoCloseOnScreenLock").toBool()){
+        lockDatabasesAfterInactivity();
+    }
 }
 
 MainWindow::~MainWindow()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -24,6 +24,7 @@
 
 #include "core/SignalMultiplexer.h"
 #include "gui/DatabaseWidget.h"
+#include "core/ScreenLockListener.h"
 
 namespace Ui {
     class MainWindow;
@@ -67,6 +68,7 @@ private Q_SLOTS:
     void toggleWindow();
     void lockDatabasesAfterInactivity();
     void repairDatabase();
+    void handleScreenLock();
 
 private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);
@@ -87,6 +89,7 @@ private:
     InactivityTimer* m_inactivityTimer;
     int m_countDefaultAttributes;
     QSystemTrayIcon* m_trayIcon;
+    ScreenLockListener* m_screenLockListener;
 
     Q_DISABLE_COPY(MainWindow)
 };

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -76,6 +76,7 @@ void SettingsWidget::loadSettings()
     m_generalUi->minimizeOnCopyCheckBox->setChecked(config()->get("MinimizeOnCopy").toBool());
     m_generalUi->useGroupIconOnEntryCreationCheckBox->setChecked(config()->get("UseGroupIconOnEntryCreation").toBool());
     m_generalUi->autoTypeEntryTitleMatchCheckBox->setChecked(config()->get("AutoTypeEntryTitleMatch").toBool());
+    m_generalUi->autoCloseOnScreenLock->setChecked(config()->get("AutoCloseOnScreenLock").toBool());
 
     m_generalUi->languageComboBox->clear();
     QList<QPair<QString, QString> > languages = Translator::availableLanguages();
@@ -120,6 +121,8 @@ void SettingsWidget::saveSettings()
     config()->set("AutoSaveAfterEveryChange",
                   m_generalUi->autoSaveAfterEveryChangeCheckBox->isChecked());
     config()->set("AutoSaveOnExit", m_generalUi->autoSaveOnExitCheckBox->isChecked());
+    config()->set("AutoCloseOnScreenLock", m_generalUi->autoCloseOnScreenLock->isChecked());
+
     config()->set("MinimizeOnCopy", m_generalUi->minimizeOnCopyCheckBox->isChecked());
     config()->set("UseGroupIconOnEntryCreation",
                   m_generalUi->useGroupIconOnEntryCreationCheckBox->isChecked());

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>456</width>
-    <height>313</height>
+    <width>762</width>
+    <height>391</height>
    </rect>
   </property>
   <layout class="QFormLayout" name="formLayout">
@@ -110,6 +110,13 @@
      </property>
      <property name="text">
       <string>Hide window to system tray when minimized</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QCheckBox" name="autoCloseOnScreenLock">
+     <property name="text">
+      <string>Close database when screen is locked or lid is closed</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Following issue [399 on redmine](https://dev.keepassx.org/issues/399), I have made the following changes:
- Added a configuration entry in general called "Close database when screen is locked or lid is closed"
- Added a class called ScreenLockListener backed by three platform specific implementations:
- on Mac OS the implementation uses the NSNotificationCenter C API
- on Linux the implementation listens to DBus signals
- on Windows the implementation registers for platform specific messages and registers a platform message handler

This change brings in the following new dependencies:
- Mac OS: Foundation framework (always present on the platform)
- Linux: Qt::DBus (available on most Linux distributions nowadays)
- Windows: wtsapi32.lib (part of the platform SDK)

I have tested on the following platforms:
- Mac OS Sierra, Qt 5.7 from online installer, XCode 8
- Ubuntu 16.10, Qt 5.7 from online installer, on Unity desktop
- Windows 7, Qt 5.7 from online installer with libraries from MSYS2

