### PR TITLE
Mention command line help option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ sudo make install
 
 More detailed instructions available in the INSTALL file.
 
+### Command line help
+
+To see what options are available from the command line, including optional arguments you can pass, execute KeePassX with the option `-h` `--help` or `-?`.
+
 ## Contribute
 
 Coordination of work between developers is handled through the [KeePassX development](https://www.keepassx.org/dev/) site.


### PR DESCRIPTION
I know it's kind of obvious, _once_ you know the answer, but I was searching and searching for documentation on how to pass arguments to the KeePassX executable and eventually found out how by looking at the source code. 