### PR TITLE
Enable DEP and ASLR.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,9 @@ if(MINGW)
   set(CMAKE_RC_COMPILER_INIT windres)
   enable_language(RC)
   set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> <FLAGS> -O coff <DEFINES> -i <SOURCE> -o <OBJECT>")
+  # Enable DEP and ASLR
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--nxcompat -Wl,--dynamicbase")
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--nxcompat -Wl,--dynamicbase")
 endif()
 
 if(APPLE OR MINGW)


### PR DESCRIPTION
## Description
Enable Data Execution Prevention (DEP) and Address Layout Randomization (ASLR) on windows.

## Motivation and Context
DEP and ASLR are simple exploit mitigation technologies. DEP is currently not enforced and ASLR is not enabled at all.

https://www.microsoft.com/security/sir/strategy/default.aspx#!section_3_3
https://blogs.technet.microsoft.com/srd/2010/12/08/on-the-effectiveness-of-dep-and-aslr/