### PR TITLE
Fix build with Qt branch 5.9

### DIFF
--- a/tests/modeltest.cpp
+++ b/tests/modeltest.cpp
@@ -447,7 +447,7 @@ void ModelTest::data()
     // Check that the alignment is one we know about
     QVariant textAlignmentVariant = model->data ( model->index ( 0, 0 ), Qt::TextAlignmentRole );
     if ( textAlignmentVariant.isValid() ) {
-        int alignment = textAlignmentVariant.toInt();
+        const uint alignment = textAlignmentVariant.toUInt();
         QCOMPARE( alignment, ( alignment & ( Qt::AlignHorizontal_Mask | Qt::AlignVertical_Mask ) ) );
     }
 


### PR DESCRIPTION
keepassx/tests/modeltest.cpp:451: undefined reference to `bool QTest::qCompare<int, unsigned int>(int const&, unsigned int const&, char const*, char const*, char const*, int)'