### PR TITLE
NOTE: KeepassX is no longer maintained.  Use KeepassXC instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # KeePassX
 
+## Note: This project is no longer maintained.
+
+You can download the last release ([v2.0.3](https://github.com/keepassx/keepassx/releases/tag/2.0.3)) or use the actively developed fork **[KeepassXC](https://github.com/keepassxreboot/keepassxc)**.
+
+
 ## About
 
 KeePassX is an application for people with extremely high demands on secure personal data management.


### PR DESCRIPTION
Considering there has been no releases since September 2016, pull requests are not being discussed or merged and the project maintainer [stopped responding to bugs in October 2016](https://dev.keepassx.org/activity?from=2016-10-27&user_id=3), it seems this project is no longer being maintaned.

I would like to suggest that we update the README in theis PR and encourage development to move to **[KeepassXC](https://github.com/keepassxreboot/keepassxc)** which has a thriving dev community: https://keepassxc.org
