### PR TITLE
Verify cancel when editing entry. 

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -465,6 +465,16 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
 
 void EditEntryWidget::cancel()
 {
+    if (this->hasBeenModified()) {
+        QMessageBox looseChanges(QMessageBox::Question,
+                "Loose changes?", "This entry has been modified, are you sure "
+                "you wish to cancel and loose all changes?",
+                QMessageBox::Yes | QMessageBox::No);
+        if (looseChanges.exec() == QMessageBox::No) {
+            return;
+        }
+    }
+
     if (m_history) {
         clear();
         Q_EMIT editFinished(false);


### PR DESCRIPTION
When a password has been altered and the user cancels the modification, make sure to ask them if they really want to throw away their changes.