### PR TITLE
update debian dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you wish to build KeePassX from source, rather than rely on the pre-compiled 
 To install KeePassX from the Debian repository:
 
 ```bash
-sudo apt-get install keepassx
+sudo apt-get install keepassx xdotool
 ```
 
 ### Red Hat


### PR DESCRIPTION
At least with the debian 9 release the xdotool it's not included, so the autotype function doesn't work properly without the xdotool package, it would be usefull to suggest to install it