### PR TITLE
Add hint for Klipper to not add passwords to history

### DIFF
--- a/src/gui/Clipboard.h
+++ b/src/gui/Clipboard.h
@@ -29,6 +29,8 @@ class Clipboard : public QObject
 public:
     void setText(const QString& text);
 
+    void setPassword(const QString& text);
+
     static Clipboard* instance();
 
 public Q_SLOTS:

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -409,7 +409,7 @@ void DatabaseWidget::copyPassword()
         return;
     }
 
-    setClipboardTextAndMinimize(currentEntry->password());
+    setClipboardPasswordAndMinimize(currentEntry->password());
 }
 
 void DatabaseWidget::copyURL()
@@ -448,6 +448,14 @@ void DatabaseWidget::copyAttribute(QAction* action)
 void DatabaseWidget::setClipboardTextAndMinimize(const QString& text)
 {
     clipboard()->setText(text);
+    if (config()->get("MinimizeOnCopy").toBool()) {
+        window()->showMinimized();
+    }
+}
+
+void DatabaseWidget::setClipboardPasswordAndMinimize(const QString& text)
+{
+    clipboard()->setPassword(text);
     if (config()->get("MinimizeOnCopy").toBool()) {
         window()->showMinimized();
     }
@@ -1020,7 +1028,7 @@ bool DatabaseWidget::eventFilter(QObject* object, QEvent* event)
                 // entry.
                 Entry* currentEntry = m_entryView->currentEntry();
                 if (currentEntry && !m_searchUi->searchEdit->hasSelectedText()) {
-                    setClipboardTextAndMinimize(currentEntry->password());
+                    setClipboardPasswordAndMinimize(currentEntry->password());
                     return true;
                 }
             }

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -152,6 +152,8 @@ private Q_SLOTS:
 
 private:
     void setClipboardTextAndMinimize(const QString& text);
+    void setClipboardPasswordAndMinimize(const QString& text);
+
     void setIconFromParent();
     void replaceDatabase(Database* db);
 


### PR DESCRIPTION
Keepassx offers an option to clear the clipboard/selection
after some time, e.g. 10 seconds, after the password was
copied to the clipboard. This works fine, but unfortunately
the password isn't removed from Klipper's history. This is
a great security risk, which may make the use of keepassx
impossible.

This patch adds the additional mime type
'x-kde-passwordManagerHint' to the mimeData when copying a
password to the clipboard. Klipper will then not insert it
into its history.

See https://phabricator.kde.org/D12539