### PR TITLE
Secure autolock option to prevent misuse

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -101,6 +101,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("security/clearclipboardtimeout", 10);
     m_defaults.insert("security/lockdatabaseidle", false);
     m_defaults.insert("security/lockdatabaseidlesec", 10);
+    m_defaults.insert("security/lockdatabasesecure", false);
     m_defaults.insert("security/passwordscleartext", false);
     m_defaults.insert("security/autotypeask", true);
     m_defaults.insert("GUI/Language", "system");

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -657,6 +657,8 @@ void DatabaseTabWidget::lockDatabases()
         // show the correct tab widget before we are asking questions about it
         setCurrentWidget(dbWidget);
 
+        if (!config()->get("security/lockdatabasesecure").toBool()) {
+
         if (mode == DatabaseWidget::EditMode && dbWidget->isEditWidgetModified()) {
             QMessageBox::StandardButton result =
                 MessageBox::question(
@@ -701,6 +703,8 @@ void DatabaseTabWidget::lockDatabases()
             else if (result == QMessageBox::Cancel) {
                 continue;
             }
+        }
+
         }
 
         dbWidget->lock();

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -103,6 +103,7 @@ void SettingsWidget::loadSettings()
 
     m_secUi->lockDatabaseIdleCheckBox->setChecked(config()->get("security/lockdatabaseidle").toBool());
     m_secUi->lockDatabaseIdleSpinBox->setValue(config()->get("security/lockdatabaseidlesec").toInt());
+    m_secUi->lockDatabaseSecureCheckBox->setChecked(config()->get("security/lockdatabasesecure").toBool());
 
     m_secUi->passwordCleartextCheckBox->setChecked(config()->get("security/passwordscleartext").toBool());
 
@@ -141,6 +142,7 @@ void SettingsWidget::saveSettings()
 
     config()->set("security/lockdatabaseidle", m_secUi->lockDatabaseIdleCheckBox->isChecked());
     config()->set("security/lockdatabaseidlesec", m_secUi->lockDatabaseIdleSpinBox->value());
+    config()->set("security/lockdatabasesecure", m_secUi->lockDatabaseSecureCheckBox->isChecked());
 
     config()->set("security/passwordscleartext", m_secUi->passwordCleartextCheckBox->isChecked());
 

--- a/src/gui/SettingsWidgetSecurity.ui
+++ b/src/gui/SettingsWidgetSecurity.ui
@@ -58,13 +58,20 @@
     </widget>
    </item>
    <item row="2" column="0">
+    <widget class="QCheckBox" name="lockDatabaseSecureCheckBox">
+     <property name="text">
+      <string>Secure Autolock - always lock on timer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QCheckBox" name="passwordCleartextCheckBox">
      <property name="text">
       <string>Show passwords in cleartext by default</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QCheckBox" name="autoTypeAskCheckBox">
      <property name="text">
       <string>Always ask before performing auto-type</string>


### PR DESCRIPTION
[Bug #609](https://dev.keepassx.org/issues/609): Keepass doesn't lock database after viewing an item

Adds a new option in settings to always autolock at the specified time interval instead of following warnings that leave the application still open.

![feature-secure-autolock](https://user-images.githubusercontent.com/19230462/39971249-1d9c7e2c-56b5-11e8-964e-87920bda9183.png)