### PR TITLE
Add confirmation when exiting entry edit when entry has been changed

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -476,8 +476,22 @@ void EditEntryWidget::cancel()
         m_entry->setIcon(Entry::DefaultIconNumber);
     }
 
-    clear();
+    if(hasBeenModified())
+    {
+        QMessageBox::StandardButton result =
+            MessageBox::question(
+            this, tr("Save changes?"),
+            tr("Entry was modified.\nSave changes?"),
+            QMessageBox::Yes | QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Cancel);
+        if (result == QMessageBox::Yes) {
+            saveEntry();
+        }
+        else if (result == QMessageBox::Cancel) {
+            return;
+        }
+    }
 
+    clear();
     Q_EMIT editFinished(false);
 }
 


### PR DESCRIPTION
Resolves [Bug #619](https://dev.keepassx.org/issues/619)

Confirmation box has three options:
Discard changes and close entry
Save changes and close entry
Cancel closing entry