### PR TITLE
Start minimized feature

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -27,6 +27,7 @@
 #include <QSplitter>
 #include <QTimer>
 #include <QProcess>
+#include <QHeaderView>
 
 #include "autotype/AutoType.h"
 #include "core/Config.h"

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -214,6 +214,10 @@ MainWindow::MainWindow()
                                 SLOT(openSearch()));
 
     updateTrayIcon();
+
+    if (isStartMinimizedEnabled()) {
+        showMinimized();
+    }
 }
 
 MainWindow::~MainWindow()
@@ -651,4 +655,8 @@ bool MainWindow::isTrayIconEnabled() const
     return config()->get("GUI/ShowTrayIcon").toBool()
             && QSystemTrayIcon::isSystemTrayAvailable();
 #endif
+}
+
+bool MainWindow::isStartMinimizedEnabled() const {
+    return config()->get("GUI/StartMinimized").toBool();
 }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -77,6 +77,7 @@ private:
     bool saveLastDatabases();
     void updateTrayIcon();
     bool isTrayIconEnabled() const;
+    bool isStartMinimizedEnabled() const;
 
     const QScopedPointer<Ui::MainWindow> m_ui;
     SignalMultiplexer m_actionMultiplexer;

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -89,6 +89,7 @@ void SettingsWidget::loadSettings()
 
     m_generalUi->systrayShowCheckBox->setChecked(config()->get("GUI/ShowTrayIcon").toBool());
     m_generalUi->systrayMinimizeToTrayCheckBox->setChecked(config()->get("GUI/MinimizeToTray").toBool());
+    m_generalUi->startMinimizedCheckBox->setChecked(config()->get("GUI/StartMinimized").toBool());
 
     if (autoType()->isAvailable()) {
         m_globalAutoTypeKey = static_cast<Qt::Key>(config()->get("GlobalAutoTypeKey").toInt());
@@ -130,6 +131,7 @@ void SettingsWidget::saveSettings()
 
     config()->set("GUI/ShowTrayIcon", m_generalUi->systrayShowCheckBox->isChecked());
     config()->set("GUI/MinimizeToTray", m_generalUi->systrayMinimizeToTrayCheckBox->isChecked());
+    config()->set("GUI/StartMinimized", m_generalUi->startMinimizedCheckBox->isChecked());
 
     if (autoType()->isAvailable()) {
         config()->set("GlobalAutoTypeKey", m_generalUi->autoTypeShortcutWidget->key());

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>456</width>
-    <height>313</height>
+    <width>465</width>
+    <height>368</height>
    </rect>
   </property>
   <layout class="QFormLayout" name="formLayout">
@@ -110,6 +110,13 @@
      </property>
      <property name="text">
       <string>Hide window to system tray when minimized</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QCheckBox" name="startMinimizedCheckBox">
+     <property name="text">
+      <string>Start minimized</string>
      </property>
     </widget>
    </item>

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -27,6 +27,7 @@
 #include <QMenu>
 #include <QSortFilterProxyModel>
 #include <QTemporaryFile>
+#include <QButtonGroup>
 
 #include "core/Config.h"
 #include "core/Database.h"


### PR DESCRIPTION
I've added new option labeled "Start minimized" in general settings. After enabling it KeePassX will start in minimized state. I think is very useful when application is loaded on system start. This feature was requested in https://dev.keepassx.org/issues/328.

I've not updated translations since this project uses Transifex. My native language is Polish, so my proposal for translation of "Start minimized" is "Uruchom zminimalizowany".

I've also fixed some errors I've encountered when building with Qt 5.11.