### PR TITLE
update Devian user's install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you wish to build KeePassX from source, rather than rely on the pre-compiled 
 To install KeePassX from the Debian repository:
 
 ```bash
-sudo apt-get install keepassx
+sudo apt install keepassx
 ```
 
 ### Red Hat


### PR DESCRIPTION
apt-get, apt-cache, etc. were integrated into the apt.
Devian users don't need apt-get anymore.