### PR TITLE
Fixing build for newer Qt versions.

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -21,6 +21,7 @@
 #include "ui_EditEntryWidgetHistory.h"
 #include "ui_EditEntryWidgetMain.h"
 
+#include <QButtonGroup>
 #include <QDesktopServices>
 #include <QStackedLayout>
 #include <QStandardPaths>

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -19,6 +19,7 @@
 #define KEEPASSX_ENTRYVIEW_H
 
 #include <QTreeView>
+#include <QHeaderView>
 
 #include "gui/entry/EntryModel.h"
 


### PR DESCRIPTION
Some types (QHeaderView, QButtonGroup) are missing full declaration now.
This issue is seen with at least Qt 5.11.1 and Qt-5.11.3