### PR TITLE
Password column in main window

### DIFF
--- a/src/gui/entry/EntryHistoryModel.cpp
+++ b/src/gui/entry/EntryHistoryModel.cpp
@@ -70,6 +70,8 @@ QVariant EntryHistoryModel::data(const QModelIndex& index, int role) const
         case 2:
             return entry->username();
         case 3:
+            return entry->password();
+        case 4:
             return entry->url();
         }
     }
@@ -88,6 +90,8 @@ QVariant EntryHistoryModel::headerData(int section, Qt::Orientation orientation,
         case 2:
             return tr("Username");
         case 3:
+            return tr("Password");
+        case 4:
             return tr("URL");
         }
     }

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -117,7 +117,7 @@ int EntryModel::columnCount(const QModelIndex& parent) const
 {
     Q_UNUSED(parent);
 
-    return 4;
+    return 5;
 }
 
 QVariant EntryModel::data(const QModelIndex& index, int role) const
@@ -139,6 +139,8 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             return entry->title();
         case Username:
             return entry->username();
+        case Password:
+            return entry->password();
         case Url:
             return entry->url();
         }
@@ -179,6 +181,8 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
             return tr("Title");
         case Username:
             return tr("Username");
+        case Password:
+            return tr("Password");
         case Url:
             return tr("URL");
         }

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -33,7 +33,8 @@ public:
         ParentGroup = 0,
         Title = 1,
         Username = 2,
-        Url = 3
+        Password = 3,
+        Url = 4
     };
 
     explicit EntryModel(QObject* parent = nullptr);


### PR DESCRIPTION
I recently switched full time from the Windows version to the KeepassX X11 version, the nice thing in the old one was the password column where you could see all the passwords at a glance and know which ones were obsolete or the same etc. It made running 1000's of hosts much easier.

TODO
- Add in the toggle to show/hide the cleartext.
- A double-click on the password should copy it, instead of opening the entry for editing. This is the same as the Windows keepass behavior as well.