### PR TITLE
Adding copy shortcuts for convenience

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -96,6 +96,8 @@ MainWindow::MainWindow()
     setShortcut(m_ui->actionEntryAutoType, QKeySequence::Paste, Qt::CTRL + Qt::Key_V);
     m_ui->actionEntryOpenUrl->setShortcut(Qt::CTRL + Qt::Key_U);
     m_ui->actionEntryCopyURL->setShortcut(Qt::CTRL + Qt::ALT + Qt::Key_U);
+    m_ui->actionEntryCopyTitle->setShortcut(Qt::CTRL + Qt::ALT + Qt::Key_T);
+    m_ui->actionEntryCopyNotes->setShortcut(Qt::CTRL + Qt::ALT + Qt::Key_N);
 
     new QShortcut(Qt::CTRL + Qt::Key_M, this, SLOT(showMinimized()));
 


### PR DESCRIPTION
Copy title (ctrl-alt-t) and copy notes (ctrl-alt-n). Often during the
day I need to copy the title as some of my user entries need different
logins, one form takes the email address and the other takes a shorter
form that I keep in the title.

For other systems I put bulk key data in the notes field.