### PR TITLE
Add option for a delay between auto-type actions

### DIFF
--- a/share/translations/keepassx_cs.ts
+++ b/share/translations/keepassx_cs.ts
@@ -1283,7 +1283,7 @@ Jedná se o jednosměrný převod. Databázi, vzniklou z importu, nepůjde otev�
         <translation>Pro vytvářenou položku použít ikonu skupiny, do které spadá</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Klávesová zkratka pro všeobecné automatické vyplňování</translation>
     </message>
     <message>

--- a/share/translations/keepassx_da.ts
+++ b/share/translations/keepassx_da.ts
@@ -1278,7 +1278,7 @@ Dette er en envejs konvertering. Du vil ikke være i stand til at åbne den impo
         <translation>Brug gruppeikon ved oprettelse af post</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Global Auto-Indsæt genvej</translation>
     </message>
     <message>

--- a/share/translations/keepassx_de.ts
+++ b/share/translations/keepassx_de.ts
@@ -1276,7 +1276,7 @@ Dieser Vorgang ist nur in eine Richtung möglich. Die importierte Datenbank kann
         <translation>Gruppensymbol für das Erstellen neuer Einträge verwenden</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Globale Tastenkombination für Auto-Type</translation>
     </message>
     <message>

--- a/share/translations/keepassx_el.ts
+++ b/share/translations/keepassx_el.ts
@@ -1203,7 +1203,7 @@ Do you want to save it anyway?</source>
         <translation>Χρησιμοποίηση εικονιδίου ομάδας κατα την δημιουργία καταχώρησης</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/share/translations/keepassx_en.ts
+++ b/share/translations/keepassx_en.ts
@@ -1303,7 +1303,7 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/keepassx_es.ts
+++ b/share/translations/keepassx_es.ts
@@ -1279,7 +1279,7 @@ Esta migración es en un único sentido. No podrá abrir la base importada con l
         <translation>Usar icono del grupo en la creación de entrada</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Atajo global de Auto-Escritura</translation>
     </message>
     <message>

--- a/share/translations/keepassx_fr.ts
+++ b/share/translations/keepassx_fr.ts
@@ -1279,7 +1279,7 @@ Ceci est une migration à sens unique. Vous ne serez plus en mesure d&apos;ouvri
         <translation>Utiliser l&apos;icône de groupe à la création d&apos;une entrée</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Raccourci de remplissage automatique global</translation>
     </message>
     <message>

--- a/share/translations/keepassx_id.ts
+++ b/share/translations/keepassx_id.ts
@@ -1279,7 +1279,7 @@ Ini adalah migrasi satu arah. Anda tidak akan bisa lagi membuka basis data yang 
         <translation>Gunakan ikon grup pada pembuatan entri</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Pintasan global Ketik-Otomatis</translation>
     </message>
     <message>

--- a/share/translations/keepassx_it.ts
+++ b/share/translations/keepassx_it.ts
@@ -1279,8 +1279,12 @@ Questa è una migrazione in una sola direzione. Non potrai aprire il database im
         <translation>Usa l&apos;icona del gruppo alla creazione di una voce</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Scorciatoia Auto-Type globale</translation>
+    </message>
+    <message>
+        <source>Global auto-type delay (ms)</source>
+        <translation>Ritardo di auto-type globale (ms)</translation>
     </message>
     <message>
         <source>Use entry title to match windows for global auto-type</source>

--- a/share/translations/keepassx_ja.ts
+++ b/share/translations/keepassx_ja.ts
@@ -1279,7 +1279,7 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <translation>エントリーを作成したらグループのアイコンを使う</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>全体の自動入力ショートカット</translation>
     </message>
     <message>

--- a/share/translations/keepassx_ko.ts
+++ b/share/translations/keepassx_ko.ts
@@ -1276,7 +1276,7 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <translation>항목을 만들 때 그룹 아이콘 사용</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>전역 자동 입력 단축키</translation>
     </message>
     <message>

--- a/share/translations/keepassx_lt.ts
+++ b/share/translations/keepassx_lt.ts
@@ -1279,7 +1279,7 @@ Tai yra vienakryptis perkėlimas. Jūs negalėsite atverti importuotos duomenų 
         <translation>Kuriant įrašus, naudoti grupės piktogramą</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Visuotinis automatinio rinkimo spartusis klavišas</translation>
     </message>
     <message>

--- a/share/translations/keepassx_nl_NL.ts
+++ b/share/translations/keepassx_nl_NL.ts
@@ -1279,7 +1279,7 @@ Deze actie is niet omkeerbaar. U kunt de geimporteerde database niet meer openen
         <translation>Gebruik icoon van de groep voor nieuwe elementen</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Globale sneltoets voor auto-typen</translation>
     </message>
     <message>

--- a/share/translations/keepassx_pl.ts
+++ b/share/translations/keepassx_pl.ts
@@ -1279,7 +1279,7 @@ Nie będzie można skonwertować nowej bazy do starego programu KeePassX 0.4.</t
         <translation>Użyj ikony grupy podczas tworzenia wpisu</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Globalny skrót auto-uzupełnianie</translation>
     </message>
     <message>

--- a/share/translations/keepassx_pt_BR.ts
+++ b/share/translations/keepassx_pt_BR.ts
@@ -1279,7 +1279,7 @@ Esta é uma migração de uma via. Você não poderá abrir o banco de dados imp
         <translation>Usar ícone de grupo na criação da entrada</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Atalho para Auto-Digitação Global</translation>
     </message>
     <message>

--- a/share/translations/keepassx_pt_PT.ts
+++ b/share/translations/keepassx_pt_PT.ts
@@ -1273,7 +1273,7 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <translation>Utilizar icon de grupo na criação de entrada</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Atalho global de auto escrita</translation>
     </message>
     <message>

--- a/share/translations/keepassx_ru.ts
+++ b/share/translations/keepassx_ru.ts
@@ -1278,7 +1278,7 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <translation>Использовать значок группы для новых записей</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Глобальное сочетание клавиш для автоввода</translation>
     </message>
     <message>

--- a/share/translations/keepassx_sl_SI.ts
+++ b/share/translations/keepassx_sl_SI.ts
@@ -1273,7 +1273,7 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <translation>Za nove vnose uporabi ikono skupine</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Globalna bližnjica za samodejno tipkanje</translation>
     </message>
     <message>

--- a/share/translations/keepassx_sv.ts
+++ b/share/translations/keepassx_sv.ts
@@ -1279,7 +1279,7 @@ Detta är en envägsmigration. Du kan inte spara en databas som KeePass1 databas
         <translation>Använd gruppens ikon för nya poster</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Globalt auto-skriv kortkommando</translation>
     </message>
     <message>

--- a/share/translations/keepassx_uk.ts
+++ b/share/translations/keepassx_uk.ts
@@ -1277,7 +1277,7 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <translation>Використовувати для нових записів значок групи</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>Глобальні сполучення клавіш для автозаповнення</translation>
     </message>
     <message>

--- a/share/translations/keepassx_zh_CN.ts
+++ b/share/translations/keepassx_zh_CN.ts
@@ -1278,7 +1278,7 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <translation>新增项目时使用群组图标</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>自动输入全局快捷键</translation>
     </message>
     <message>

--- a/share/translations/keepassx_zh_TW.ts
+++ b/share/translations/keepassx_zh_TW.ts
@@ -1279,7 +1279,7 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <translation>新增項目時使用群組圖示</translation>
     </message>
     <message>
-        <source>Global Auto-Type shortcut</source>
+        <source>Global auto-type shortcut</source>
         <translation>全域自動輸入快捷鍵</translation>
     </message>
     <message>

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -164,6 +164,7 @@ void AutoType::performAutoType(const Entry* entry, QWidget* hideWindow, const QS
         }
 
         action->accept(m_executor);
+        Tools::sleep(config()->get("GlobalAutoTypeDelay").toInt());
         QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
     }
 

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -41,6 +41,8 @@ SettingsWidget::SettingsWidget(QWidget* parent)
 
     m_generalUi->autoTypeShortcutWidget->setVisible(autoType()->isAvailable());
     m_generalUi->autoTypeShortcutLabel->setVisible(autoType()->isAvailable());
+    m_generalUi->autoTypeDelaySpinBox->setVisible(autoType()->isAvailable());
+    m_generalUi->autoTypeDelayLabel->setVisible(autoType()->isAvailable());
 #ifdef Q_OS_MAC
     // systray not useful on OS X
     m_generalUi->systrayShowCheckBox->setVisible(false);
@@ -96,6 +98,7 @@ void SettingsWidget::loadSettings()
         if (m_globalAutoTypeKey > 0 && m_globalAutoTypeModifiers > 0) {
             m_generalUi->autoTypeShortcutWidget->setShortcut(m_globalAutoTypeKey, m_globalAutoTypeModifiers);
         }
+        m_generalUi->autoTypeDelaySpinBox->setValue(config()->get("GlobalAutoTypeDelay").toInt());
     }
 
     m_secUi->clearClipboardCheckBox->setChecked(config()->get("security/clearclipboard").toBool());
@@ -135,6 +138,7 @@ void SettingsWidget::saveSettings()
         config()->set("GlobalAutoTypeKey", m_generalUi->autoTypeShortcutWidget->key());
         config()->set("GlobalAutoTypeModifiers",
                       static_cast<int>(m_generalUi->autoTypeShortcutWidget->modifiers()));
+        config()->set("GlobalAutoTypeDelay", m_generalUi->autoTypeDelaySpinBox->value());
     }
     config()->set("security/clearclipboard", m_secUi->clearClipboardCheckBox->isChecked());
     config()->set("security/clearclipboardtimeout", m_secUi->clearClipboardSpinBox->value());

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -72,7 +72,7 @@
    <item row="7" column="0">
     <widget class="QLabel" name="autoTypeShortcutLabel">
      <property name="text">
-      <string>Global Auto-Type shortcut</string>
+      <string>Global auto-type shortcut</string>
      </property>
     </widget>
    </item>
@@ -80,30 +80,50 @@
     <widget class="ShortcutWidget" name="autoTypeShortcutWidget"/>
    </item>
    <item row="8" column="0">
+    <widget class="QLabel" name="autoTypeDelayLabel">
+     <property name="text">
+      <string>Global auto-type delay (ms)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QSpinBox" name="autoTypeDelaySpinBox">
+     <property name="suffix">
+      <string> ms</string>
+     </property>
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>999</number>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
     <widget class="QCheckBox" name="autoTypeEntryTitleMatchCheckBox">
      <property name="text">
       <string>Use entry title to match windows for global auto-type</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="0">
+   <item row="10" column="0">
     <widget class="QLabel" name="languageLabel">
      <property name="text">
       <string>Language</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
+   <item row="10" column="1">
     <widget class="QComboBox" name="languageComboBox"/>
    </item>
-   <item row="10" column="0">
+   <item row="11" column="0">
     <widget class="QCheckBox" name="systrayShowCheckBox">
      <property name="text">
       <string>Show a system tray icon</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="0">
+   <item row="12" column="0">
     <widget class="QCheckBox" name="systrayMinimizeToTrayCheckBox">
      <property name="enabled">
       <bool>false</bool>


### PR DESCRIPTION
Add option for a delay between auto-type actions. This makes auto-type work properly for older machines where Linux (and maybe other OSes) swallows keystrokes that are sent too rapidly. Currently auto-type on my older laptop rarely gets processed without some letters being dropped. This feature makes it usable.

Changes:

- New spinner in the settings dialogue to enter a ms delay. Defaults to 0.
- Italian translation of the label for that new spinner.
- Auto-type sleeps between each keystroke action for the number of ms saved in the settings.
- I also fixed a small capitalization issue in the settings dialogue.